### PR TITLE
Added 'mafia testci'

### DIFF
--- a/src/Mafia/Process.hs
+++ b/src/Mafia/Process.hs
@@ -30,6 +30,9 @@ module Mafia.Process
   , callFrom_
   , exec
   , execFrom
+
+    -- * Internal (exported for testing)
+  , cleanLines
   ) where
 
 import           Control.Concurrent.Async (Async, async, waitCatch)

--- a/src/Mafia/Process.hs
+++ b/src/Mafia/Process.hs
@@ -14,6 +14,7 @@ module Mafia.Process
 
     -- * Outputs
   , Pass(..)
+  , Clean(..)
   , Hush(..)
   , Out(..)
   , Err(..)
@@ -32,8 +33,8 @@ module Mafia.Process
   ) where
 
 import           Control.Concurrent.Async (Async, async, waitCatch)
-import           Control.Exception (SomeException)
-import           Control.Monad.Catch (MonadCatch(..), handle)
+import           Control.Exception (SomeException, IOException)
+import           Control.Monad.Catch (MonadCatch(..), handle, bracket_)
 import           Control.Monad.IO.Class (MonadIO(..))
 
 import           Data.ByteString (ByteString)
@@ -51,7 +52,8 @@ import           Mafia.IO (setCurrentDirectory)
 import           P
 
 import           System.Exit (ExitCode(..))
-import           System.IO (FilePath)
+import           System.IO (IO, FilePath, Handle, BufferMode(..))
+import qualified System.IO as IO
 import qualified System.Process as Process
 import qualified System.Posix.Process as Posix
 
@@ -75,6 +77,11 @@ data Process = Process
 
 -- | Pass @stdout@ and @stderr@ through to the console.
 data Pass = Pass
+  deriving (Eq, Ord, Show)
+
+-- | Pass @stdout@ and @stderr@ through to the console, but process control
+--   characters (such as \b, \r) prior to emitting each line of output.
+data Clean = Clean
   deriving (Eq, Ord, Show)
 
 -- | Capture @stdout@ and @stderr@ but ignore them.
@@ -159,6 +166,22 @@ instance ProcessResult Hush where
   callProcess p = do
     OutErr (_ :: ByteString) (_ :: ByteString) <- callProcess p
     return Hush
+
+instance ProcessResult Clean where
+  callProcess p = withProcess p $ do
+    let cp = (fromProcess p) { Process.std_out = Process.CreatePipe
+                             , Process.std_err = Process.CreatePipe }
+
+    (Nothing, Just hOut, Just hErr, pid) <- liftIO (Process.createProcess cp)
+
+    asyncOut <- liftIO (async (clean hOut IO.stdout))
+    asyncErr <- liftIO (async (clean hErr IO.stderr))
+
+    ()   <- waitCatchE p asyncOut
+    ()   <- waitCatchE p asyncErr
+    code <- liftIO (Process.waitForProcess pid)
+
+    return (code, Clean)
 
 instance ProcessResult (Out Text) where
   callProcess p = fmap T.decodeUtf8 <$> callProcess p
@@ -315,3 +338,48 @@ handleAll p = handle (hoistEither . Left . ProcessException p)
 
 waitCatchE :: (Functor m, MonadIO m) => Process -> Async a -> EitherT ProcessError m a
 waitCatchE p = firstEitherT (ProcessException p) . EitherT . liftIO . waitCatch
+
+------------------------------------------------------------------------
+
+clean :: Handle -> Handle -> IO ()
+clean input output = do
+  ibuf <- IO.hGetBuffering input
+  obuf <- IO.hGetBuffering output
+
+  let setLineBuffering = do
+        IO.hSetBuffering input  LineBuffering
+        IO.hSetBuffering output LineBuffering
+
+      ignoreIOE (_ :: IOException) = return ()
+
+      -- the handles may be closed by the time we
+      -- try to reset the buffer mode, so we need
+      -- to catch exceptions
+      resetBuffering = do
+        handle ignoreIOE (IO.hSetBuffering input  ibuf)
+        handle ignoreIOE (IO.hSetBuffering output obuf)
+
+  bracket_ setLineBuffering resetBuffering $ do
+    xs <- IO.hGetContents input
+    IO.hPutStr output (cleanLines [] xs)
+
+
+cleanLines :: [Char] -- ^ current line
+           -> [Char] -- ^ input
+           -> [Char] -- ^ output
+
+-- backspace - delete previous character
+cleanLines (_ : line) ('\b' : xs) = cleanLines line xs
+cleanLines []         ('\b' : xs) = cleanLines []   xs
+
+-- carriage return - delete the whole line
+cleanLines _          ('\r' : xs) = cleanLines []   xs
+
+-- line feed - emit the current line
+cleanLines line       ('\n' : xs) = reverse ('\n' : line) <> cleanLines [] xs
+
+-- normal character - add to current line
+cleanLines line       (x    : xs) = cleanLines (x : line) xs
+
+-- end of stream - emit the current line
+cleanLines line       []          = line

--- a/test/Test/Mafia/Process.hs
+++ b/test/Test/Mafia/Process.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+module Test.Mafia.Process where
+
+import           Mafia.Process
+
+import           P
+
+import           Test.QuickCheck
+
+
+prop_clean xs =
+  counterexample "contained \\b or \\r" $
+  all (`notElem` dirtyChars) (cleanLines [] xs)
+
+
+dirtyChars :: [Char]
+dirtyChars = "\b\r"
+
+
+return []
+tests = $quickCheckAll

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,5 +1,9 @@
 import           Disorder.Core.Main
 
+import qualified Test.Mafia.Process
+
 main :: IO ()
 main =
-  disorderMain []
+  disorderMain [
+      Test.Mafia.Process.tests
+    ]


### PR DESCRIPTION
This will be needed for Icicle to build on Travis and we might as well switch all of the projects over to using it so that we don't get this sort of output from QuickCheck:

```
(0 tests)         (1 test)        (2 tests)         (3 tests)         (4 tests)         (5 tests)         (6 tests)         (7 tests)         (8 tests)         (9 tests)         (10 tests)          (11 tests)          (12 tests)          (13 tests)          (14 tests)          (15 tests)          (16 tests)          (17 tests)          (18 tests)          (19 tests)          (20 tests)          (21 tests)          (22 tests)          (23 tests)          (24 tests)          (25 tests)          (26 tests)          (27 tests)          (28 tests)          (29 tests)          (30 tests)          (31 tests)          (32 tests)          (33 tests)          (34 tests)          (35 tests)          (36 tests)          (37 tests)          (38 tests)          (39 tests)          (40 tests)...
```
