### PR TITLE
Fixed bug where cabal would trash its sandbox and be unable to add/delete-source

### DIFF
--- a/mafia.cabal
+++ b/mafia.cabal
@@ -23,6 +23,7 @@ library
                     , exceptions                      == 0.8.*
                     , filepath                        == 1.4.*
                     , process                         == 1.2.*
+                    , tar                             == 0.4.*
                     , text                            == 1.2.*
                     , time                            == 1.4.*
                     , transformers                    == 0.4.*
@@ -38,6 +39,7 @@ library
                     Paths_ambiata_mafia
                     BuildInfo_ambiata_mafia
                     Mafia
+                    Mafia.Cabal
                     Mafia.IO
                     Mafia.Path
                     Mafia.Process

--- a/mafia.cabal
+++ b/mafia.cabal
@@ -106,9 +106,13 @@ test-suite test-io
                     , ambiata-disorder-corpus
                     , ambiata-mafia
                     , ambiata-p
+                    , ambiata-x-either
+                    , exceptions                      == 0.8.*
                     , QuickCheck                      == 2.7.*
                     , quickcheck-instances            == 0.3.*
+                    , temporary                       == 1.2.*
                     , text                            == 1.2.*
+                    , transformers                    == 0.4.*
 
 test-suite test-cli
   type:

--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -30,8 +30,8 @@ import           P
 import           System.Exit
 import           System.IO
 
-import           X.Options.Applicative
 import           X.Control.Monad.Trans.Either
+import           X.Options.Applicative
 
 ------------------------------------------------------------------------
 
@@ -382,7 +382,7 @@ removeSandboxSource dir = do
   rel <- fromMaybe dir <$> makeRelativeToCurrentDirectory dir
   liftIO (T.hPutStrLn stderr ("Sandbox: Removing " <> rel))
   -- TODO Unregister packages contained in this source dir
-  sandbox_ "delete-source" [dir]
+  sandbox_ "delete-source" ["-v0", dir]
 
 getSandboxSources :: EitherT MafiaViolation IO (Set Directory)
 getSandboxSources = do

--- a/src/Mafia/Cabal.hs
+++ b/src/Mafia/Cabal.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Mafia.Cabal
+  ( SandboxDir
+  , CabalError(..)
+  , repairIndexFile
+  ) where
+
+import           Control.Exception (IOException)
+import           Control.Monad.Catch (catch)
+import           Control.Monad.IO.Class (MonadIO(..))
+
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as L
+import qualified Data.Text.Encoding as T
+
+import qualified Codec.Archive.Tar as Tar
+
+import           Mafia.IO
+import           Mafia.Path
+
+import           P
+
+import           System.IO (IO)
+
+import           X.Control.Monad.Trans.Either
+
+------------------------------------------------------------------------
+
+type SandboxDir = Directory
+
+data CabalError =
+    IndexFileNotFound File
+  | CorruptIndexFile Tar.FormatError
+  deriving (Show)
+
+------------------------------------------------------------------------
+
+readIndexFile :: MonadIO m => File -> EitherT CabalError m ByteString
+readIndexFile file = do
+  mbs <- readBytes file
+  hoistEither $ maybe (Left (IndexFileNotFound file)) Right mbs
+
+readEntries :: Monad m => ByteString -> EitherT CabalError m [Tar.Entry]
+readEntries bs = do
+  let tar = Tar.read (L.fromStrict bs)
+  hoistEither $ Tar.foldEntries (\x -> fmap (x :)) (Right []) (Left . CorruptIndexFile) tar
+
+isTreeRef :: Tar.Entry -> Bool
+isTreeRef x = Tar.entryPath x == "local-build-tree-reference/"
+
+fromEntry :: Tar.Entry -> Maybe Directory
+fromEntry x =
+  case Tar.entryContent x of
+    Tar.OtherEntryType _ lbs _ | isTreeRef x -> Just (T.decodeUtf32LE (L.toStrict lbs))
+    _                                        -> Nothing
+
+------------------------------------------------------------------------
+
+repairIndexFile :: SandboxDir -> EitherT CabalError IO ()
+repairIndexFile = filterEntries doesDirectoryExist
+
+filterEntries :: (Directory -> IO Bool) -> File -> EitherT CabalError IO ()
+filterEntries pred sandboxDir = do
+  let indexFile  = sandboxDir </> "packages/00-index.tar"
+      indexCache = sandboxDir </> "packages/00-index.cache"
+
+  bytes   <- readIndexFile indexFile
+  entries <- readEntries bytes
+
+  let pred' = maybe (pure True) pred . fromEntry
+  entries' <- liftIO (filterM pred' entries)
+
+  when (length entries /= length entries') $ do
+    let bytes' = L.toStrict (Tar.write entries')
+    writeBytes indexFile bytes'
+    removeFile indexCache `catch` \(_ :: IOException) -> pure ()

--- a/src/Mafia/IO.hs
+++ b/src/Mafia/IO.hs
@@ -7,6 +7,7 @@ module Mafia.IO
   , getDirectoryListing
   , getDirectoryContents
   , createDirectoryIfMissing
+  , removeDirectoryRecursive
   , setCurrentDirectory
   , getCurrentDirectory
   , makeRelativeToCurrentDirectory
@@ -82,6 +83,10 @@ getDirectoryContents path = liftIO $ do
 createDirectoryIfMissing :: MonadIO m => Bool -> Directory -> m ()
 createDirectoryIfMissing parents dir =
   liftIO (Directory.createDirectoryIfMissing parents (T.unpack dir))
+
+removeDirectoryRecursive :: MonadIO m => Directory -> m ()
+removeDirectoryRecursive dir =
+  liftIO (Directory.removeDirectoryRecursive (T.unpack dir))
 
 setCurrentDirectory :: MonadIO m => Directory -> m ()
 setCurrentDirectory dir = liftIO (Directory.setCurrentDirectory (T.unpack dir))

--- a/test/Test/IO/Mafia/Chaos.hs
+++ b/test/Test/IO/Mafia/Chaos.hs
@@ -1,0 +1,152 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+module Test.IO.Mafia.Chaos where
+
+import           Control.Exception (IOException)
+import           Control.Monad.Catch
+import           Control.Monad.IO.Class (MonadIO(..))
+
+import           Disorder.Corpus
+import           Disorder.Core.IO
+
+import           Data.Char (toUpper)
+import           Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+
+import           Mafia.IO
+import           Mafia.Path
+import           Mafia.Process
+
+import           P
+
+import           System.IO (IO, print)
+import           System.IO.Temp (withSystemTempDirectory)
+
+import           Test.QuickCheck
+
+import           X.Control.Monad.Trans.Either
+
+------------------------------------------------------------------------
+
+data Action =
+    Build
+  | AddLib    Text
+  | RemoveLib Text
+  deriving (Eq, Ord, Show)
+
+instance Arbitrary Action where
+  arbitrary = oneof [ AddLib    <$> genPackageName
+                    , RemoveLib <$> genPackageName
+                    , pure Build ]
+
+genPackageName :: Gen Text
+genPackageName = T.replace " " "-" <$> elements viruses
+
+------------------------------------------------------------------------
+
+bracketDirectory :: IO a -> IO a
+bracketDirectory io = bracket getCurrentDirectory setCurrentDirectory (const io)
+
+withTempDirectory :: Testable a => (Directory -> EitherT ProcessError IO a) -> Property
+withTempDirectory io = testIO . bracketDirectory $ do
+  result  <- withSystemTempDirectory "mafia.chaos" (runEitherT . io . T.pack)
+  case result of
+    Left  err -> return (counterexample (show err) False)
+    Right x   -> return (property x)
+
+hush :: (MonadIO m, MonadCatch m) => a -> m a -> m a
+hush def = handle $ \(_ :: IOException) -> return def
+
+------------------------------------------------------------------------
+
+writeRootProject :: (MonadIO m, MonadCatch m) => m ()
+writeRootProject = do
+  libs <- hush [] $ getDirectoryContents "lib"
+  writeProject "." "root" libs
+
+writeProject :: MonadIO m => Directory -> Text -> [Text] -> m ()
+writeProject dir name deps = do
+  let src     = dir </> "src"
+      modName = dromedary name
+
+  writeFile (dir </> name <> ".cabal")
+            (cabalText name deps)
+
+  writeFile (src </> modName <> ".hs")
+            ("module " <> modName <> " where\n")
+
+writeFile :: MonadIO m => Path -> Text -> m ()
+writeFile path txt = do
+  createDirectoryIfMissing True (takeDirectory path)
+  writeText path txt
+
+dromedary :: Text -> Text
+dromedary = mconcat . fmap upcase . T.splitOn "-"
+  where
+    upcase xs | T.null xs = xs
+              | otherwise = T.singleton (toUpper (T.head xs)) <> T.tail xs
+
+cabalText :: Text -> [Text] -> Text
+cabalText name deps = T.unlines [
+    "name:          acme-" <> name
+  , "version:       0.0.1"
+  , "license:       AllRightsReserved"
+  , "author:        Mafia Chaos"
+  , "maintainer:    Mafia Chaos"
+  , "synopsis:      synopsis"
+  , "category:      Development"
+  , "cabal-version: >= 1.8"
+  , "build-type:    Simple"
+  , "description:   description"
+  , ""
+  , "library"
+  , "  hs-source-dirs: src"
+  , "  build-depends:"
+  , "      base >= 3 && < 5"
+  ] <> T.unlines (fmap ("    , acme-" <>) deps)
+
+------------------------------------------------------------------------
+
+prop_chaos (actions :: [Action]) = withTempDirectory $ \temp -> do
+  liftIO (print actions)
+
+  mafia <- (</> "dist/build/mafia/mafia") <$> getCurrentDirectory
+
+  setCurrentDirectory temp
+  call_ id "git" ["init"]
+  writeRootProject
+
+  forM_ actions $ \action -> do
+    runAction mafia action
+
+  return True
+
+runAction :: File -> Action -> EitherT ProcessError IO ()
+runAction mafia = \case
+  AddLib lib -> do
+    let dir = "lib" </> lib
+    liftIO (T.putStrLn ("+ " <> dir))
+
+    writeProject dir lib []
+    writeRootProject
+
+  RemoveLib lib -> do
+    let dir = "lib" </> lib
+    liftIO (T.putStrLn ("- " <> dir))
+
+    hush () $ removeDirectoryRecursive dir
+    writeRootProject
+
+  Build -> do
+    liftIO (T.putStrLn "$ mafia build")
+    call_ id mafia ["build"]
+
+------------------------------------------------------------------------
+
+return []
+tests = $forAllProperties $ quickCheckWithResult (stdArgs {maxSuccess = 10})

--- a/test/test-io.hs
+++ b/test/test-io.hs
@@ -1,6 +1,9 @@
 import           Disorder.Core.Main
 
+import qualified Test.IO.Mafia.Chaos
+
 main :: IO ()
 main =
   disorderMain [
+      Test.IO.Mafia.Chaos.tests
     ]


### PR DESCRIPTION
If you ever delete a directory which you have previously added to a cabal sandbox via add-source then cabal will be unable to add-source or remove-source from then on.

The fix is a rather complex workaround unfortunately :( We create the directory which cabal is looking for and put a dummy cabal file in it.
