### PR TITLE
Use `git submodule` to detect which lib/ folders to use

### DIFF
--- a/mafia.cabal
+++ b/mafia.cabal
@@ -40,6 +40,7 @@ library
                     BuildInfo_ambiata_mafia
                     Mafia
                     Mafia.Cabal
+                    Mafia.Git
                     Mafia.IO
                     Mafia.Path
                     Mafia.Process

--- a/src/Mafia/Git.hs
+++ b/src/Mafia/Git.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Mafia.Git
+    ( GitError(..)
+    , getProjectRoot
+
+    , SubmoduleState
+    , Submodule(..)
+    , subNeedsInit
+    , initSubmodules
+    , getSubmodules
+    ) where
+
+import           Data.Text (Text)
+import qualified Data.Text as T
+
+import           Mafia.Path
+import           Mafia.Process
+
+import           P
+
+import           System.IO (IO)
+
+import           X.Control.Monad.Trans.Either (EitherT, left)
+
+------------------------------------------------------------------------
+
+data GitError =
+    GitProcessError ProcessError
+  | GitParseError Text
+  deriving (Show)
+
+data SubmoduleState = NeedsInit | Ready
+  deriving (Eq, Ord, Show)
+
+data Submodule = Submodule
+  { subState :: SubmoduleState
+  , subName  :: Directory
+  } deriving (Eq, Ord, Show)
+
+subNeedsInit :: Submodule -> Bool
+subNeedsInit = (== NeedsInit) . subState
+
+------------------------------------------------------------------------
+
+getProjectRoot :: EitherT GitError IO File
+getProjectRoot =
+  T.strip . unOut <$> call GitProcessError "git" ["rev-parse", "--show-toplevel"]
+
+------------------------------------------------------------------------
+
+-- Init any submodules that we need. Don't worry about explicit submodules
+-- file here, we just want to trust git to tell us things that haven't been
+-- initialized, we really _don't_ want to run this just because a module is
+-- dirty from development changes etc...
+initSubmodules :: EitherT GitError IO ()
+initSubmodules = do
+  root <- getProjectRoot
+  ss   <- fmap subName . filter subNeedsInit <$> getSubmodules
+
+  forM_ ss $ \s ->
+    callFrom_ GitProcessError root "git" ["submodule", "update", "--init", s]
+
+getSubmodules :: EitherT GitError IO [Submodule]
+getSubmodules = do
+  root    <- getProjectRoot
+  Out out <- callFrom GitProcessError root "git" ["submodule"]
+
+  sequence . fmap parseSubmoduleLine . T.lines $ out
+
+parseSubmoduleLine :: Text -> EitherT GitError IO Submodule
+parseSubmoduleLine line = Submodule (parseSubmoduleState line) <$> parseSubmoduleName line
+
+parseSubmoduleState :: Text -> SubmoduleState
+parseSubmoduleState line
+  | "-" `T.isPrefixOf` line = NeedsInit
+  | otherwise               = Ready
+
+parseSubmoduleName :: Text -> EitherT GitError IO Text
+parseSubmoduleName line =
+  case T.words line of
+    (_:x:_) -> pure x
+    _       -> left (GitParseError ("failed to read submodule name from: " <> line))

--- a/src/Mafia/IO.hs
+++ b/src/Mafia/IO.hs
@@ -11,6 +11,7 @@ module Mafia.IO
   , setCurrentDirectory
   , getCurrentDirectory
   , makeRelativeToCurrentDirectory
+  , canonicalizePath
 
     -- * Existence Tests
   , doesFileExist
@@ -99,6 +100,10 @@ makeRelativeToCurrentDirectory path = do
   current <- getCurrentDirectory
   absPath <- T.pack `liftM` liftIO (Directory.makeAbsolute (T.unpack path))
   return (makeRelative current absPath)
+
+canonicalizePath :: MonadIO m => Path -> m Path
+canonicalizePath path =
+  T.pack `liftM` liftIO (Directory.canonicalizePath (T.unpack path))
 
 ------------------------------------------------------------------------
 -- Existence Tests

--- a/src/Mafia/Path.hs
+++ b/src/Mafia/Path.hs
@@ -10,6 +10,7 @@ module Mafia.Path
   , (</>)
   , takeFileName
   , takeDirectory
+  , dropTrailingPathSeparator
   , makeRelative
 
     -- * Extension functions
@@ -44,6 +45,9 @@ takeFileName = T.pack . FilePath.takeFileName . T.unpack
 
 takeDirectory :: Path -> Directory
 takeDirectory = T.pack . FilePath.takeDirectory . T.unpack
+
+dropTrailingPathSeparator :: Directory -> Directory
+dropTrailingPathSeparator = T.pack . FilePath.dropTrailingPathSeparator . T.unpack
 
 makeRelative :: Path -> Path -> Maybe Path
 makeRelative xp yp =


### PR DESCRIPTION
Not sure if this is controversial or not?

This changes mafia to use _only_ the registered submodules from the `lib/` directory when building.

This should fix the situation where you switch branches and a submodule is unregistered in the process.
