### PR TITLE
Allow relocatable sandboxes

### DIFF
--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -324,6 +324,7 @@ initialize = do
     cabal_ "install" [ "-j"
                      , "--only-dependencies"
                      , "--force-reinstalls"
+                     , "--enable-relocatable"
                      , "--enable-tests"
                      , "--enable-benchmarks"
                      , "--reorder-goals"


### PR DESCRIPTION
This cabal feature is somewhat undocumented, but turns out it has been available for some time (since 1.22 was released). Essentially, it means that sandboxes can be copied around! It works by replacing the paths in the sandbox, which are traditionally absolute, by paths relative to a magic `${pkgroot}` variable.

I tried it out like this:

``` sh
/mismi/mismi-s3 $ mafia build
# Much sandboxing occurs, including amazonka
/mismi/mismi-s3 $ cd ../mismi-ec2
/mismi/mismi-ec2 $ cp -r ../mismi-s3/.cabal-sandbox .
/mismi/mismi-ec2 $ mafia build
Cache: Updating mismi-ec2.cabal
Cache: Removing mismi-s3.cabal
Resolving dependencies...
Notice: installing into a sandbox located at
/mismi/mismi-ec2/.cabal-sandbox
Downloading amazonka-ec2-1.3.6...
Configuring amazonka-ec2-1.3.6...
Building amazonka-ec2-1.3.6...
Installed amazonka-ec2-1.3.6
Resolving dependencies...
Configuring ambiata-mismi-ec2-0.0.1...
Building ambiata-mismi-ec2-0.0.1...
```

As you can see, it didn't build `amazonka` twice, it was just the additional `amazonka-ec2` package. 

The downside is that some packages which depend on native libraries don't install properly, for example `postgresql-simple`:

``` sh
/test $ cabal install --enable-relocatable postgresql-simple
Resolving dependencies...
Notice: installing into a sandbox located at
/test/.cabal-sandbox
Configuring postgresql-libpq-0.9.1.1...
Building postgresql-libpq-0.9.1.1...
Installed postgresql-libpq-0.9.1.1
Downloading postgresql-simple-0.5.1.1...
Configuring postgresql-simple-0.5.1.1...
Failed to install postgresql-simple-0.5.1.1
Build log ( /test/.cabal-sandbox/logs/postgresql-simple-0.5.1.1.log ):
Configuring postgresql-simple-0.5.1.1...
setup-Simple-Cabal-1.22.4.0-x86_64-osx-ghc-7.8.4: Library directory of a
dependency: "/usr/local/lib"
is not relative to the installation prefix:
"/test/.cabal-sandbox"
cabal: Error: some packages failed to install:
postgresql-simple-0.5.1.1 failed during the configure step. The exception was:
ExitFailure 1
```

This PR can't be merged until we solve the above issue, but I think this could be a huge win if we work it out.

/cc @markhibberd @nhibberd @charleso 
