### PR TITLE
Ensure quoted arguments get passed to mafia executable

### DIFF
--- a/script/mafia
+++ b/script/mafia
@@ -57,7 +57,7 @@ exec_mafia () {
       mv "${MAFIA_PATH}.tmp" "$MAFIA_PATH"
     }
 
-    exec $MAFIA_PATH $@
+    exec $MAFIA_PATH "$@"
   fi
 }
 


### PR DESCRIPTION
Running `./mafia hoogle "a -> b"` doesn't like the `-`

/cc @olorin and anyone who knows this shit
