### PR TITLE
Keep a ghc version specific sandbox

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,6 +1,7 @@
 #!/usr/bin/env runhaskell
 
 import           Data.Time (formatTime, getCurrentTime)
+import           Data.Time.Locale.Compat (defaultTimeLocale)
 import           Data.List (intercalate)
 import           Data.Version (showVersion)
 
@@ -13,7 +14,6 @@ import           Distribution.Simple.BuildPaths (autogenModulesDir)
 import           Distribution.Simple.Utils (createDirectoryIfMissingVerbose, rewriteFile)
 
 import           System.FilePath ((</>), (<.>))
-import           System.Locale (defaultTimeLocale)
 import           System.Process (readProcess)
 
 main :: IO ()

--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -28,6 +28,7 @@ library
                     , temporary                       == 1.2.*
                     , text                            == 1.2.*
                     , time                            >= 1.4        && < 1.6
+                    , time-locale-compat              == 0.1.*
                     , transformers                    == 0.4.*
                     , unix                            == 2.7.*
 
@@ -69,6 +70,7 @@ executable mafia
                     , temporary
                     , text                            == 1.2.*
                     , time                            >= 1.4        && < 1.6
+                    , time-locale-compat              == 0.1.*
                     , transformers                    == 0.4.*
 
 

--- a/mafia.cabal
+++ b/mafia.cabal
@@ -27,7 +27,7 @@ library
                     , tar                             == 0.4.*
                     , temporary                       == 1.2.*
                     , text                            == 1.2.*
-                    , time                            == 1.4.*
+                    , time                            >= 1.4        && < 1.6
                     , transformers                    == 0.4.*
                     , unix                            == 2.7.*
 
@@ -68,7 +68,7 @@ executable mafia
                     , optparse-applicative            == 0.11.*
                     , temporary
                     , text                            == 1.2.*
-                    , time                            == 1.4.*
+                    , time                            >= 1.4        && < 1.6
                     , transformers                    == 0.4.*
 
 


### PR DESCRIPTION
This updates mafia to create a sandbox specific to the version of ghc it finds on the path, so you might end up with the following sort of structure:

```
.cabal-sandbox/7.8.4
.cabal-sandbox/7.10.2
```

One annoying thing is that `cabal.sandbox.config` must be updated to point to the correct sandbox. We could work around this by setting the `CABAL_SANDBOX_CONFIG` environment variable when using mafia, but it would mean that if people use cabal directly then it wouldn't work.

I was also able to build mafia on 7.10 by just widening the bounds on time and upgrading p, so I have done that too.
