### PR TITLE
Crude work-around for when (savages) clean.

### DIFF
--- a/src/Mafia/Cache.hs
+++ b/src/Mafia/Cache.hs
@@ -43,7 +43,8 @@ import           X.Control.Monad.Trans.Either (EitherT, hoistEither, runEitherT)
 initialize :: EitherT MafiaViolation IO ()
 initialize = do
   updates <- determineCacheUpdates
-  when (updates /= []) $ do
+  hasDist <- liftIO $ doesDirectoryExist "dist"
+  when (updates /= [] || not hasDist) $ do
     -- we want to know up front why we're doing an install/configure
     let sortedUpdates = List.sort updates
     mapM_ putUpdateReason sortedUpdates


### PR DESCRIPTION
Currently if you run cabal clean the configure
doesn't not get triggered on subsequent commands
because the cabal file isn't detemined to be out
of date. This just checks if dist exists and
forcibly configures in that case, this is crude
and there are probably holes in it, but covers
a common case.
