### PR TITLE
Add support for parsing the reinstall section of a package install plan

### DIFF
--- a/src/Mafia/Install.hs
+++ b/src/Mafia/Install.hs
@@ -201,7 +201,6 @@ install w env p@(Package (PackageRef pid _ msrc) deps _) = do
                                     , "--haddock-hoogle"
                                     , "--haddock-hyperlink-source"
                                     , "--max-backjumps=0"
-                                    , "--force-reinstalls"
                                     , renderPackageId pid
                                     ] <> constraints
 

--- a/src/Mafia/Install.hs
+++ b/src/Mafia/Install.hs
@@ -201,6 +201,7 @@ install w env p@(Package (PackageRef pid _ msrc) deps _) = do
                                     , "--haddock-hoogle"
                                     , "--haddock-hyperlink-source"
                                     , "--max-backjumps=0"
+                                    , "--force-reinstalls"
                                     , renderPackageId pid
                                     ] <> constraints
 

--- a/test/Test/Mafia/Arbitrary.hs
+++ b/test/Test/Mafia/Arbitrary.hs
@@ -9,7 +9,6 @@ import qualified Data.Text as T
 
 import           Disorder.Corpus (muppets, cooking)
 
-import           Mafia.Cabal.Dependencies
 import           Mafia.Cabal.Types
 import           Mafia.Package
 

--- a/test/Test/Mafia/Arbitrary.hs
+++ b/test/Test/Mafia/Arbitrary.hs
@@ -26,11 +26,15 @@ instance Arbitrary PackageName where
 
 instance Arbitrary Version where
   arbitrary =
-    Version <$> listOf1 (choose (0, 100)) <*> pure []
+    Version <$>
+      listOf1 (choose (0, 100)) <*>
+      pure []
 
 instance Arbitrary PackageId where
   arbitrary =
-    PackageId <$> arbitrary <*> arbitrary
+    PackageId <$>
+      arbitrary <*>
+      arbitrary
 
 instance Arbitrary Flag where
   arbitrary =
@@ -40,8 +44,28 @@ instance Arbitrary Flag where
 
 instance Arbitrary PackageRef where
   arbitrary =
-    PackageRef <$> arbitrary <*> arbitrary <*> pure Nothing
+    PackageRef <$>
+      arbitrary <*>
+      arbitrary <*>
+      pure Nothing
 
-instance Arbitrary RevDeps where
+instance Arbitrary PackageChange where
   arbitrary =
-    RevDeps <$> arbitrary <*> arbitrary
+    PackageChange <$>
+      arbitrary <*>
+      arbitrary
+
+instance Arbitrary PackageStatus where
+  arbitrary =
+    oneof
+      [ pure NewPackage
+      , pure NewVersion
+      , Reinstall <$> listOf1 arbitrary ]
+
+instance Arbitrary PackagePlan where
+  arbitrary =
+    PackagePlan <$>
+      arbitrary <*>
+      arbitrary <*>
+      arbitrary <*>
+      arbitrary

--- a/test/Test/Mafia/Cabal/Dependencies.hs
+++ b/test/Test/Mafia/Cabal/Dependencies.hs
@@ -15,8 +15,8 @@ import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
 
 
-prop_roundtrip_RevDeps =
-  tripping renderRevDeps parseRevDeps
+prop_roundtrip_PackagePlan =
+  tripping renderPackagePlan parsePackagePlan
 
 return []
 tests = $quickCheckAll

--- a/test/cli/basic-usage/run
+++ b/test/cli/basic-usage/run
@@ -32,5 +32,6 @@ check() {
 EOF
 }
 
-check p p          src/P.hs
-check x x/x-either src/X/Control/Monad/Trans/Either.hs
+check p p           src/P.hs
+check x x/x-eithert src/X/Control/Monad/Trans/Either.hs
+check x x/x-conduit src/X/Data/Conduit/Binary.hs


### PR DESCRIPTION
I thought reinstalls could never happen because we always had a fresh
sandbox. It turns out they can because there are a few packages like
process, filepath, directory, etc that are in the global package
database which is installed by default.

Ideally we could just exclude the global package database alltogether
but we need it for base and possibly ghc.

/cc @charleso 

This needs to be merged before we can proceed with the upgrade on `x` because `x-conduit` does a reinstall of `process`.
