### PR TITLE
Install binaries with all their support files

### DIFF
--- a/src/Mafia/Home.hs
+++ b/src/Mafia/Home.hs
@@ -51,30 +51,27 @@ installBinary package deps = do
   tmp <- ensureMafiaDir "tmp"
   let nv = renderPackageId package
   bin <- ensureMafiaDir "bin"
-  let path = bin </> nv
+  let prefix = bin </> nv
+      path = prefix </> "bin"
+      installArgs p = [ "install", renderPackageId p, "--prefix=" <> prefix ]
   -- This is to support old versions of mafia that had installed a single executable
   -- We can remove this at some point
   -- NOTE: This makes no attempt at being threadsafe
-  liftIO (doesFileExist path) >>= \b -> when b $ do
-    renameFile path (path <> ".tmp")
-    createDirectoryIfMissing True path
-    renameFile (path <> ".tmp") (path </> (unPackageName . pkgName) package)
-  liftIO (doesDirectoryExist path) >>= \case
-    True ->
-      pure path
-    False -> do
-      EitherT . withTempDirectory (T.unpack tmp) (T.unpack $ nv <> ".") $ \sandboxDir -> runEitherT $ do
-        Pass <- callFrom id (T.pack sandboxDir) "cabal" ["sandbox", "init"]
-        -- Install any required executables first
-        -- This could also recursively call `installBinary` and copy the output in to the sandbox if we do this again
-        for_ deps $ \p -> do
-          Pass <- callFrom id (T.pack sandboxDir) "cabal" ["install", renderPackageId p]
-          pure ()
-        Pass <- callFrom id (T.pack sandboxDir) "cabal" ["install", nv]
-        createDirectoryIfMissing True path
-        getDirectoryListing (RecursiveDepth 1) (T.pack sandboxDir </> ".cabal-sandbox" </> "bin") >>= \p ->
-          for_ p $ \f -> copyFile f (path </> takeFileName f)
-        return path
+  liftIO (doesFileExist prefix) >>= \b -> when b $ do
+    renameFile prefix (prefix <> ".tmp")
+    createDirectoryIfMissing True prefix
+    renameFile (prefix <> ".tmp") (prefix </> (unPackageName . pkgName) package)
+  unlessM (liftIO (doesDirectoryExist path)) $
+    EitherT . withTempDirectory (T.unpack tmp) (T.unpack $ nv <> ".") $ \sandboxDir -> runEitherT $ do
+      -- Build the binary and its dependencies in a new sandbox.
+      -- Sandbox necessary as binary's deps could clash with the local project
+      Pass <- callFrom id (T.pack sandboxDir) "cabal" ["sandbox", "init"]
+      -- Install any required executables first
+      for_ deps ensureExeOnPath
+      createDirectoryIfMissing True prefix
+      Pass <- callFrom id (T.pack sandboxDir) "cabal" (installArgs package)
+      pure ()
+  pure path
 
 ensureExeOnPath :: PackageId -> EitherT ProcessError IO ()
 ensureExeOnPath pkg = do

--- a/test/cli/hoogle/run
+++ b/test/cli/hoogle/run
@@ -13,5 +13,5 @@ cd ${MAFIA_TEMP}
 git clone git@github.com:ambiata/p.git
 cd p
 
-${MAFIA} hoogle "length" | grep -F "Prelude length :: [a] -> Int"
+${MAFIA} hoogle "fst" | grep -F "Prelude fst :: (a, b) -> a"
 ${MAFIA} hoogle "(Int -> Int) -> [Int] -> [Int]" | grep -F "Prelude fmap :: Functor f => (a -> b) -> f a -> f b"


### PR DESCRIPTION
Replaces `cabal install; cp` with `cabal install --prefix=$MAFIABIN/packageName-0.1.1`. All the supporting files (happy templates etc) get copied properly, and we return `$MAFIABIN/packageName-0.1.1/bin` instead.

Currently this will break if an old version of mafia has installed stuff, I'll add a workaround...
