### PR TITLE
Disable event logging in profiling builds (doesn't work with -P)

### DIFF
--- a/src/Mafia/Init.hs
+++ b/src/Mafia/Init.hs
@@ -123,7 +123,6 @@ profilingArgs = \case
       "--enable-profiling"
     , "--disable-executable-stripping"
     , "--ghc-options=-fprof-auto-top"
-    , "--ghc-options=-eventlog"
     ]
 
 -- If a user or an older version of mafia has used 'cabal sandbox add-source'


### PR DESCRIPTION
/cc @jystic 
