### PR TITLE
Upgrade nitpicks

### DIFF
--- a/script/mafia
+++ b/script/mafia
@@ -19,13 +19,19 @@ local_version () {
 
 run_upgrade () {
   MAFIA_TEMP=$(mktemp 2>/dev/null || mktemp -t 'upgrade_mafia')
-  MAFIA_CUR="$0"
 
   clean_up () {
     rm -f "$MAFIA_TEMP"
   }
 
   trap clean_up EXIT
+
+  MAFIA_CUR="$0"
+
+  if [ -L "$MAFIA_CUR" ]; then
+    echo 'Refusing to overwrite a symlink; run `upgrade` from the canonical path.' >&2
+    exit 1
+  fi
 
   echo "Checking for a new version of mafia ..."
   fetch_latest > $MAFIA_TEMP

--- a/script/mafia
+++ b/script/mafia
@@ -19,6 +19,7 @@ local_version () {
 
 run_upgrade () {
   MAFIA_TEMP=$(mktemp 2>/dev/null || mktemp -t 'upgrade_mafia')
+  MAFIA_CUR="$0"
 
   clean_up () {
     rm -f "$MAFIA_TEMP"
@@ -32,9 +33,9 @@ run_upgrade () {
   LATEST_VERSION=$(latest_version)
   echo "# Version: $LATEST_VERSION" >> $MAFIA_TEMP
 
-  if ! cmp ./mafia $MAFIA_TEMP >/dev/null 2>&1; then
-    mv $MAFIA_TEMP ./mafia
-    chmod +x ./mafia
+  if ! cmp $MAFIA_CUR $MAFIA_TEMP >/dev/null 2>&1; then
+    mv $MAFIA_TEMP $MAFIA_CUR
+    chmod +x $MAFIA_CUR
     echo "New version found and upgraded. You can now commit it to your git repo."
   else
     echo "You have latest mafia."

--- a/script/mafia
+++ b/script/mafia
@@ -33,9 +33,9 @@ run_upgrade () {
   echo "# Version: $LATEST_VERSION" >> $MAFIA_TEMP
 
   if ! cmp ./mafia $MAFIA_TEMP >/dev/null 2>&1; then
-    echo "New version found and upgraded. You can now commit it to your git repo."
     mv $MAFIA_TEMP ./mafia
     chmod +x ./mafia
+    echo "New version found and upgraded. You can now commit it to your git repo."
   else
     echo "You have latest mafia."
   fi


### PR DESCRIPTION
- don't assume `mafia` is always `./mafia`
- bail out when trying to upgrade a symlink (fixes #22)
- don't print success message on upgrade until the new version is in place

/cc @jystic @nhibberd 
