### PR TITLE
Allow mafia to be used with the development version (1.23.*) of cabal

### DIFF
--- a/src/Mafia/Cabal/Version.hs
+++ b/src/Mafia/Cabal/Version.hs
@@ -50,7 +50,7 @@ checkCabalVersion = do
   --   https://github.com/haskell/cabal/commit/c0b3c7f1b6ae7bb7663a2c18578ede95d6a40919
 
   let vmin = Version [1,22,4] []
-      vmax = Version [1,23]   []
+      vmax = Version [1,24]   []
 
   version <- getCabalVersion
 


### PR DESCRIPTION
cabal >= 1.23 is required for building with GHC 8.0 RC1, and thanks to recent commits, it now works properly with mafia
