### PR TITLE
Display which source package was to blame when 'cabal sdist' fails

### DIFF
--- a/src/Mafia/Cabal/Package.hs
+++ b/src/Mafia/Cabal/Package.hs
@@ -112,7 +112,9 @@ hashSourcePackage :: Directory -> EitherT CabalError IO SourcePackageHash
 hashSourcePackage dir = do
   ignoredFiles <- Set.fromList <$> readIgnoredFiles dir
 
-  OutErr _ err <- callFrom CabalProcessError dir "cabal" ["sdist", "--list-sources=/dev/stderr"]
+  rdir <- tryMakeRelativeToCurrent dir
+  let sdistError _ = CabalSDistFailed rdir
+  OutErr _ err <- callFrom sdistError dir "cabal" ["sdist", "--list-sources=/dev/stderr"]
 
   let sdistFiles = Set.fromList (fmap normalise (T.lines err))
       files      = Set.toList (sdistFiles `Set.difference` ignoredFiles)

--- a/src/Mafia/Cabal/Types.hs
+++ b/src/Mafia/Cabal/Types.hs
@@ -169,6 +169,7 @@ data CabalError =
   | CabalSandboxConfigFileNotFound SandboxConfigFile
   | CabalSandboxConfigFieldNotFound SandboxConfigFile Text
   | CabalInstallIsNotReferentiallyTransparent
+  | CabalSDistFailed Directory
   | CabalReinstallsDetected [PackagePlan]
   | CabalCouldNotReadPackageId File
   | CabalCouldNotParseVersion Text
@@ -207,6 +208,9 @@ renderCabalError = \case
 
   CabalInstallIsNotReferentiallyTransparent ->
     "The impossible happened, cabal-install gave different answers on subsequent dry runs"
+
+  CabalSDistFailed dir ->
+    "Failed to run 'cabal sdist' for source package: " <> dir
 
   CabalCouldNotReadPackageId cabalFile ->
     "Failed to read package-id from: " <> cabalFile


### PR DESCRIPTION
/cc @nhibberd @markhibberd 
