### PR TITLE
Add 'mafia depends' to show dependencies of current package

### DIFF
--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -22,6 +22,7 @@ library
                     , attoparsec                      == 0.12.*
                     , base16-bytestring               == 0.1.*
                     , bytestring                      == 0.10.*
+                    , case-insensitive                == 1.2.*
                     , containers                      == 0.5.*
                     , cryptohash                      == 0.11.*
                     , directory                       == 1.2.*
@@ -67,6 +68,7 @@ library
                     Mafia.Process
                     Mafia.Project
                     Mafia.Submodule
+                    Mafia.Tree
                     Paths_ambiata_mafia
 
 executable mafia

--- a/src/Mafia/Cabal/Types.hs
+++ b/src/Mafia/Cabal/Types.hs
@@ -13,6 +13,7 @@ module Mafia.Cabal.Types
   , PackageRef(..)
   , SourcePackage(..)
   , mkPackage
+  , renderPackageRef
   , renderHashId
 
   , PackagePlan(..)
@@ -99,6 +100,20 @@ data PackagePlan =
 mkPackage :: PackageRef -> [Package] -> Package
 mkPackage ref deps =
   Package ref deps (hashPackage ref deps)
+
+renderPackageRef :: PackageRef -> Text
+renderPackageRef = \case
+  PackageRef pid flags Nothing ->
+    renderPackageId pid <> renderFlagsSuffix flags
+  PackageRef pid flags (Just (SourcePackage _ _ hash)) ->
+    renderPackageId pid <> "-" <> renderHash hash <> renderFlagsSuffix flags
+
+renderFlagsSuffix :: [Flag] -> Text
+renderFlagsSuffix = \case
+  [] ->
+    T.empty
+  xs ->
+    " " <> T.intercalate " " (fmap renderFlag xs)
 
 renderHashId :: Package -> Text
 renderHashId (Package (PackageRef pid _ _) _ hash) =

--- a/src/Mafia/Error.hs
+++ b/src/Mafia/Error.hs
@@ -3,15 +3,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Mafia.Error
   ( MafiaError (..)
-  , CacheUpdate (..)
   , renderMafiaError
   , liftCabal
   ) where
 
-import           Control.Exception (IOException)
-
 import           Data.Text (Text)
-import qualified Data.Text as T
 
 import           Mafia.Cabal.Types
 import           Mafia.Git
@@ -27,13 +23,6 @@ import           P
 import           X.Control.Monad.Trans.Either (EitherT)
 
 
--- FIX This should live in Cache
-data CacheUpdate
-  = Add    File File
-  | Update File File
-  | Delete File
-  deriving (Eq, Ord, Show)
-
 -- FIX Leaving this to make code cleanup easier, but ideally is a union of
 -- sub-exceptions rather than this module being the root of most dependencies
 data MafiaError
@@ -46,7 +35,6 @@ data MafiaError
   | MafiaHashError HashError
   | MafiaInitError InitError
   | MafiaParseError Text
-  | MafiaCacheUpdateError CacheUpdate IOException
   | MafiaEntryPointNotFound File
   deriving (Show)
 
@@ -79,10 +67,6 @@ renderMafiaError = \case
 
   MafiaParseError msg ->
     "Parse failed: " <> msg
-
-  MafiaCacheUpdateError x ex ->
-    "Cache update failed: " <> T.pack (show x) <>
-    "\n" <> T.pack (show ex)
 
   MafiaEntryPointNotFound path ->
     "GHCi entry point not found: " <> path

--- a/src/Mafia/Init.hs
+++ b/src/Mafia/Init.hs
@@ -6,6 +6,7 @@
 module Mafia.Init
   ( Profiling(..)
   , initialize
+  , getSourceDependencies
 
   , InitError(..)
   , renderInitError
@@ -93,9 +94,10 @@ initialize mprofiling mflags = do
 
   when needInstall $ do
     liftIO (T.putStrLn "Installing dependencies...")
-    let sdeps    = Set.toList (msSourceDependencies current)
+    let sdeps = Set.toList (msSourceDependencies current)
         flavours = profilingFlavour (msProfiling current)
-    firstT InitInstallError $ installDependencies flavours sdeps
+        flags = msFlags current
+    firstT InitInstallError $ installDependencies flavours flags sdeps
 
   let needConfigure = needInstall || not hasDist
 
@@ -125,13 +127,6 @@ profilingArgs = \case
     , "--disable-executable-stripping"
     , "--ghc-options=-fprof-auto-top"
     ]
-
-flagArg :: Flag -> Argument
-flagArg = \case
-  FlagOff f ->
-    "--flags=-" <> f
-  FlagOn f ->
-    "--flags=" <> f
 
 -- If a user or an older version of mafia has used 'cabal sandbox add-source'
 -- then some source dependencies can get installed twice unecessarily. This

--- a/src/Mafia/Package.hs
+++ b/src/Mafia/Package.hs
@@ -14,11 +14,12 @@ module Mafia.Package
   ) where
 
 import           Data.Aeson (Value(..), ToJSON(..), FromJSON(..))
+import qualified Data.CaseInsensitive as CI
 import qualified Data.Char as Char
-import           Data.Version (Version (..))
-import qualified Data.Version as Version
 import           Data.Text (Text)
 import qualified Data.Text as T
+import           Data.Version (Version (..))
+import qualified Data.Version as Version
 
 import           P
 
@@ -36,8 +37,13 @@ data PackageId =
   PackageId {
       pkgName :: PackageName
     , pkgVersion :: Version
-    } deriving (Eq, Ord, Show)
+    } deriving (Eq, Show)
 
+instance Ord PackageId where
+  compare (PackageId xn xv) (PackageId yn yv) =
+    compare
+      (CI.mk $ unPackageName xn, xv)
+      (CI.mk $ unPackageName yn, yv)
 
 packageId :: Text -> [Int] -> PackageId
 packageId n v =


### PR DESCRIPTION
This adds support for `mafia depends` and `mafia depends --tree` (or `mafia depends -t`) which, as an example, gives the following output on mafia itself:
#### mafia depends

```
$ mafia depends
aeson-0.8.0.2 +old-locale
ambiata-disorder-core-0.0.1-4d73a2fdb30c255434d37cbed9d7dee8feaa7a7e
ambiata-disorder-corpus-0.0.1-f5ef0e865e27b950e3f76e9bcdf172d0b89450da
ambiata-p-0.0.1-5ac1fbfc47e28490db66ea959fc9bddc55456d00
ambiata-twine-0.0.1-caf2e76454b20fcb0e001d03d50080b0b9153c60
ambiata-x-eithert-0.0.1-2be3c283eedb551496c2796ce1221eb7e4464758
ambiata-x-exception-0.0.1-e2e84f18475f307b668261c1af0d024044fd3488
ambiata-x-optparse-0.0.1-b4dbdb36ba29497a29ff82251c9e2811efc32f49
ansi-terminal-0.6.2.3
ansi-wl-pprint-0.6.7.3
async-2.0.2
attoparsec-0.12.1.6
base16-bytestring-0.1.1.6
bifunctors-5
byteable-0.1.1
case-insensitive-1.2.0.5
cryptohash-0.11.6
directory-1.2.5.0
dlist-0.7.1.2
exceptions-0.8.2.1
filelock-0.1.0.1
filepath-1.4.1.0
hashable-1.2.4.0
ieee754-0.7.8
monad-loops-0.4.3
mtl-2.2.1
nats-1.1
optparse-applicative-0.11.0.2
primitive-0.6.1.0
process-1.2.3.0
QuickCheck-2.8.2 -base4point8
quickcheck-instances-0.3.12
quickcheck-text-0.1.0.1
random-1.1
SafeSemaphore-0.10.1
scientific-0.3.4.4
semigroups-0.18.1
stm-2.4.4.1
syb-0.6
tagged-0.8.3
tar-0.4.5.0
temporary-1.2.0.4
text-1.2.2.0
tf-random-0.5
time-locale-compat-0.1.1.1
transformers-0.4.3.0
transformers-compat-0.4.0.4
unordered-containers-0.2.6.0
vector-0.11.0.0
```
#### mafia depends --tree

```
$ mafia depends --tree
aeson-0.8.0.2 +old-locale
 ├─╼ attoparsec-0.12.1.6
 │    ├─╼ scientific-0.3.4.4
 │    │    ├─╼ hashable-1.2.4.0
 │    │    │    └─╼ text-1.2.2.0
 │    │    ├─╼ text-1.2.2.0
 │    │    └─╼ vector-0.11.0.0
 │    │         └─╼ primitive-0.6.1.0
 │    │              └─╼ transformers-0.4.3.0
 │    └─╼ text-1.2.2.0
 ├─╼ dlist-0.7.1.2
 ├─╼ hashable-1.2.4.0
 │    └─╼ text-1.2.2.0
 ├─╼ mtl-2.2.1
 │    └─╼ transformers-0.4.3.0
 ├─╼ scientific-0.3.4.4
 │    ├─╼ hashable-1.2.4.0
 │    │    └─╼ text-1.2.2.0
 │    ├─╼ text-1.2.2.0
 │    └─╼ vector-0.11.0.0
 │         └─╼ primitive-0.6.1.0
 │              └─╼ transformers-0.4.3.0
 ├─╼ syb-0.6
 ├─╼ text-1.2.2.0
 ├─╼ unordered-containers-0.2.6.0
 │    └─╼ hashable-1.2.4.0
 │         └─╼ text-1.2.2.0
 └─╼ vector-0.11.0.0
      └─╼ primitive-0.6.1.0
           └─╼ transformers-0.4.3.0
ambiata-disorder-core-0.0.1-4d73a2fdb30c255434d37cbed9d7dee8feaa7a7e
 ├─╼ directory-1.2.5.0
 │    └─╼ filepath-1.4.1.0
 ├─╼ ieee754-0.7.8
 ├─╼ process-1.2.3.0
 │    ├─╼ directory-1.2.5.0
 │    │    └─╼ filepath-1.4.1.0
 │    └─╼ filepath-1.4.1.0
 ├─╼ QuickCheck-2.8.2 -base4point8
 │    ├─╼ random-1.1
 │    ├─╼ tf-random-0.5
 │    │    ├─╼ primitive-0.6.1.0
 │    │    │    └─╼ transformers-0.4.3.0
 │    │    └─╼ random-1.1
 │    └─╼ transformers-0.4.3.0
 ├─╼ quickcheck-text-0.1.0.1
 │    ├─╼ QuickCheck-2.8.2 -base4point8
 │    │    ├─╼ random-1.1
 │    │    ├─╼ tf-random-0.5
 │    │    │    ├─╼ primitive-0.6.1.0
 │    │    │    │    └─╼ transformers-0.4.3.0
 │    │    │    └─╼ random-1.1
 │    │    └─╼ transformers-0.4.3.0
 │    └─╼ text-1.2.2.0
 ├─╼ text-1.2.2.0
 └─╼ transformers-0.4.3.0
ambiata-disorder-corpus-0.0.1-f5ef0e865e27b950e3f76e9bcdf172d0b89450da
 └─╼ text-1.2.2.0
ambiata-p-0.0.1-5ac1fbfc47e28490db66ea959fc9bddc55456d00
 ├─╼ bifunctors-5
 │    ├─╼ semigroups-0.18.1
 │    │    ├─╼ hashable-1.2.4.0
 │    │    │    └─╼ text-1.2.2.0
 │    │    ├─╼ nats-1.1
 │    │    │    └─╼ hashable-1.2.4.0
 │    │    │         └─╼ text-1.2.2.0
 │    │    ├─╼ tagged-0.8.3
 │    │    ├─╼ text-1.2.2.0
 │    │    ├─╼ transformers-0.4.3.0
 │    │    └─╼ unordered-containers-0.2.6.0
 │    │         └─╼ hashable-1.2.4.0
 │    │              └─╼ text-1.2.2.0
 │    └─╼ tagged-0.8.3
 ├─╼ semigroups-0.18.1
 │    ├─╼ hashable-1.2.4.0
 │    │    └─╼ text-1.2.2.0
 │    ├─╼ nats-1.1
 │    │    └─╼ hashable-1.2.4.0
 │    │         └─╼ text-1.2.2.0
 │    ├─╼ tagged-0.8.3
 │    ├─╼ text-1.2.2.0
 │    ├─╼ transformers-0.4.3.0
 │    └─╼ unordered-containers-0.2.6.0
 │         └─╼ hashable-1.2.4.0
 │              └─╼ text-1.2.2.0
 └─╼ transformers-0.4.3.0
ambiata-twine-0.0.1-caf2e76454b20fcb0e001d03d50080b0b9153c60
 ├─╼ ambiata-p-0.0.1-5ac1fbfc47e28490db66ea959fc9bddc55456d00
 │    ├─╼ bifunctors-5
 │    │    ├─╼ semigroups-0.18.1
 │    │    │    ├─╼ hashable-1.2.4.0
 │    │    │    │    └─╼ text-1.2.2.0
 │    │    │    ├─╼ nats-1.1
 │    │    │    │    └─╼ hashable-1.2.4.0
 │    │    │    │         └─╼ text-1.2.2.0
 │    │    │    ├─╼ tagged-0.8.3
 │    │    │    ├─╼ text-1.2.2.0
 │    │    │    ├─╼ transformers-0.4.3.0
 │    │    │    └─╼ unordered-containers-0.2.6.0
 │    │    │         └─╼ hashable-1.2.4.0
 │    │    │              └─╼ text-1.2.2.0
 │    │    └─╼ tagged-0.8.3
 │    ├─╼ semigroups-0.18.1
 │    │    ├─╼ hashable-1.2.4.0
 │    │    │    └─╼ text-1.2.2.0
 │    │    ├─╼ nats-1.1
 │    │    │    └─╼ hashable-1.2.4.0
 │    │    │         └─╼ text-1.2.2.0
 │    │    ├─╼ tagged-0.8.3
 │    │    ├─╼ text-1.2.2.0
 │    │    ├─╼ transformers-0.4.3.0
 │    │    └─╼ unordered-containers-0.2.6.0
 │    │         └─╼ hashable-1.2.4.0
 │    │              └─╼ text-1.2.2.0
 │    └─╼ transformers-0.4.3.0
 ├─╼ ambiata-x-eithert-0.0.1-2be3c283eedb551496c2796ce1221eb7e4464758
 │    ├─╼ ambiata-x-exception-0.0.1-e2e84f18475f307b668261c1af0d024044fd3488
 │    │    └─╼ exceptions-0.8.2.1
 │    │         ├─╼ mtl-2.2.1
 │    │         │    └─╼ transformers-0.4.3.0
 │    │         ├─╼ stm-2.4.4.1
 │    │         ├─╼ transformers-0.4.3.0
 │    │         └─╼ transformers-compat-0.4.0.4
 │    │              └─╼ transformers-0.4.3.0
 │    ├─╼ exceptions-0.8.2.1
 │    │    ├─╼ mtl-2.2.1
 │    │    │    └─╼ transformers-0.4.3.0
 │    │    ├─╼ stm-2.4.4.1
 │    │    ├─╼ transformers-0.4.3.0
 │    │    └─╼ transformers-compat-0.4.0.4
 │    │         └─╼ transformers-0.4.3.0
 │    ├─╼ text-1.2.2.0
 │    └─╼ transformers-0.4.3.0
 ├─╼ async-2.0.2
 │    └─╼ stm-2.4.4.1
 ├─╼ exceptions-0.8.2.1
 │    ├─╼ mtl-2.2.1
 │    │    └─╼ transformers-0.4.3.0
 │    ├─╼ stm-2.4.4.1
 │    ├─╼ transformers-0.4.3.0
 │    └─╼ transformers-compat-0.4.0.4
 │         └─╼ transformers-0.4.3.0
 ├─╼ monad-loops-0.4.3
 ├─╼ SafeSemaphore-0.10.1
 │    └─╼ stm-2.4.4.1
 ├─╼ stm-2.4.4.1
 ├─╼ text-1.2.2.0
 └─╼ transformers-0.4.3.0
ambiata-x-eithert-0.0.1-2be3c283eedb551496c2796ce1221eb7e4464758
 ├─╼ ambiata-x-exception-0.0.1-e2e84f18475f307b668261c1af0d024044fd3488
 │    └─╼ exceptions-0.8.2.1
 │         ├─╼ mtl-2.2.1
 │         │    └─╼ transformers-0.4.3.0
 │         ├─╼ stm-2.4.4.1
 │         ├─╼ transformers-0.4.3.0
 │         └─╼ transformers-compat-0.4.0.4
 │              └─╼ transformers-0.4.3.0
 ├─╼ exceptions-0.8.2.1
 │    ├─╼ mtl-2.2.1
 │    │    └─╼ transformers-0.4.3.0
 │    ├─╼ stm-2.4.4.1
 │    ├─╼ transformers-0.4.3.0
 │    └─╼ transformers-compat-0.4.0.4
 │         └─╼ transformers-0.4.3.0
 ├─╼ text-1.2.2.0
 └─╼ transformers-0.4.3.0
ambiata-x-optparse-0.0.1-b4dbdb36ba29497a29ff82251c9e2811efc32f49
 ├─╼ attoparsec-0.12.1.6
 │    ├─╼ scientific-0.3.4.4
 │    │    ├─╼ hashable-1.2.4.0
 │    │    │    └─╼ text-1.2.2.0
 │    │    ├─╼ text-1.2.2.0
 │    │    └─╼ vector-0.11.0.0
 │    │         └─╼ primitive-0.6.1.0
 │    │              └─╼ transformers-0.4.3.0
 │    └─╼ text-1.2.2.0
 ├─╼ optparse-applicative-0.11.0.2
 │    ├─╼ ansi-wl-pprint-0.6.7.3
 │    │    └─╼ ansi-terminal-0.6.2.3
 │    ├─╼ process-1.2.3.0
 │    │    ├─╼ directory-1.2.5.0
 │    │    │    └─╼ filepath-1.4.1.0
 │    │    └─╼ filepath-1.4.1.0
 │    ├─╼ transformers-0.4.3.0
 │    └─╼ transformers-compat-0.4.0.4
 │         └─╼ transformers-0.4.3.0
 ├─╼ text-1.2.2.0
 └─╼ transformers-0.4.3.0
async-2.0.2
 └─╼ stm-2.4.4.1
attoparsec-0.12.1.6
 ├─╼ scientific-0.3.4.4
 │    ├─╼ hashable-1.2.4.0
 │    │    └─╼ text-1.2.2.0
 │    ├─╼ text-1.2.2.0
 │    └─╼ vector-0.11.0.0
 │         └─╼ primitive-0.6.1.0
 │              └─╼ transformers-0.4.3.0
 └─╼ text-1.2.2.0
base16-bytestring-0.1.1.6
case-insensitive-1.2.0.5
 ├─╼ hashable-1.2.4.0
 │    └─╼ text-1.2.2.0
 └─╼ text-1.2.2.0
cryptohash-0.11.6
 └─╼ byteable-0.1.1
directory-1.2.5.0
 └─╼ filepath-1.4.1.0
exceptions-0.8.2.1
 ├─╼ mtl-2.2.1
 │    └─╼ transformers-0.4.3.0
 ├─╼ stm-2.4.4.1
 ├─╼ transformers-0.4.3.0
 └─╼ transformers-compat-0.4.0.4
      └─╼ transformers-0.4.3.0
filelock-0.1.0.1
filepath-1.4.1.0
optparse-applicative-0.11.0.2
 ├─╼ ansi-wl-pprint-0.6.7.3
 │    └─╼ ansi-terminal-0.6.2.3
 ├─╼ process-1.2.3.0
 │    ├─╼ directory-1.2.5.0
 │    │    └─╼ filepath-1.4.1.0
 │    └─╼ filepath-1.4.1.0
 ├─╼ transformers-0.4.3.0
 └─╼ transformers-compat-0.4.0.4
      └─╼ transformers-0.4.3.0
process-1.2.3.0
 ├─╼ directory-1.2.5.0
 │    └─╼ filepath-1.4.1.0
 └─╼ filepath-1.4.1.0
QuickCheck-2.8.2 -base4point8
 ├─╼ random-1.1
 ├─╼ tf-random-0.5
 │    ├─╼ primitive-0.6.1.0
 │    │    └─╼ transformers-0.4.3.0
 │    └─╼ random-1.1
 └─╼ transformers-0.4.3.0
quickcheck-instances-0.3.12
 ├─╼ hashable-1.2.4.0
 │    └─╼ text-1.2.2.0
 ├─╼ QuickCheck-2.8.2 -base4point8
 │    ├─╼ random-1.1
 │    ├─╼ tf-random-0.5
 │    │    ├─╼ primitive-0.6.1.0
 │    │    │    └─╼ transformers-0.4.3.0
 │    │    └─╼ random-1.1
 │    └─╼ transformers-0.4.3.0
 ├─╼ scientific-0.3.4.4
 │    ├─╼ hashable-1.2.4.0
 │    │    └─╼ text-1.2.2.0
 │    ├─╼ text-1.2.2.0
 │    └─╼ vector-0.11.0.0
 │         └─╼ primitive-0.6.1.0
 │              └─╼ transformers-0.4.3.0
 ├─╼ text-1.2.2.0
 ├─╼ unordered-containers-0.2.6.0
 │    └─╼ hashable-1.2.4.0
 │         └─╼ text-1.2.2.0
 └─╼ vector-0.11.0.0
      └─╼ primitive-0.6.1.0
           └─╼ transformers-0.4.3.0
tar-0.4.5.0
 ├─╼ directory-1.2.5.0
 │    └─╼ filepath-1.4.1.0
 └─╼ filepath-1.4.1.0
temporary-1.2.0.4
 ├─╼ directory-1.2.5.0
 │    └─╼ filepath-1.4.1.0
 ├─╼ exceptions-0.8.2.1
 │    ├─╼ mtl-2.2.1
 │    │    └─╼ transformers-0.4.3.0
 │    ├─╼ stm-2.4.4.1
 │    ├─╼ transformers-0.4.3.0
 │    └─╼ transformers-compat-0.4.0.4
 │         └─╼ transformers-0.4.3.0
 ├─╼ filepath-1.4.1.0
 └─╼ transformers-0.4.3.0
text-1.2.2.0
time-locale-compat-0.1.1.1
transformers-0.4.3.0
```

The format for hackage dependencies is `<package name>-<version> <flags>`, and the format for source dependencies is `<package name>-<version>-<hash> <flags>`. The `<hash>` for source dependencies is the hash of the actual source code (as produced by `mafia hash`) not the git commit hash.
