### PR TITLE
Add cabal configure flags support

### DIFF
--- a/src/Mafia/Cabal/Types.hs
+++ b/src/Mafia/Cabal/Types.hs
@@ -7,6 +7,7 @@ module Mafia.Cabal.Types
 
   , Flag(..)
   , renderFlag
+  , parseFlag
 
   , Package(..)
   , PackageRef(..)
@@ -28,6 +29,7 @@ module Mafia.Cabal.Types
 import qualified Codec.Archive.Tar as Tar
 
 import           Data.Aeson (Value(..), ToJSON(..), FromJSON(..), (.:), (.=), object)
+import           Data.Char (isAlpha)
 import           Data.Text (Text)
 import qualified Data.Text as T
 
@@ -124,6 +126,20 @@ renderFlag :: Flag -> Text
 renderFlag = \case
   FlagOff f -> "-" <> f
   FlagOn  f -> "+" <> f
+
+parseFlag :: Alternative f => Text -> f Flag
+parseFlag f0 =
+  case T.uncons f0 of
+    Just ('-', f1) ->
+      pure $ FlagOff f1
+    Just ('+', f1) ->
+      pure $ FlagOn f1
+    Just (x, _) | isAlpha x ->
+      pure $ FlagOn f0
+    Just _ ->
+      empty
+    Nothing ->
+      empty
 
 renderPackagePlan :: PackagePlan -> Text
 renderPackagePlan (PackagePlan (PackageRef pid fs _) latest deps status) =

--- a/src/Mafia/Hoogle.hs
+++ b/src/Mafia/Hoogle.hs
@@ -48,7 +48,7 @@ hoogle hackageRoot args = do
 
 hooglePackages :: Text -> EitherT MafiaError IO HooglePackagesSandbox
 hooglePackages hackageRoot = do
-  firstT MafiaInitError $ initialize Nothing
+  firstT MafiaInitError $ initialize Nothing Nothing
   db <- hoogleCacheDir
   hoogleExe <- installHoogle
   Out pkgStr <- liftCabal $ sandbox "hc-pkg" ["list"]

--- a/test/Test/Mafia/Cabal/Types.hs
+++ b/test/Test/Mafia/Cabal/Types.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+module Test.Mafia.Cabal.Types where
+
+import           Data.Text (Text)
+
+import           Disorder.Core.Tripping (tripping)
+
+import           Mafia.Cabal.Types
+
+import           P
+
+import           Test.Mafia.Arbitrary ()
+import           Test.QuickCheck
+import           Test.QuickCheck.Instances ()
+
+
+prop_roundtrip_Flag =
+  tripping renderFlag (parseFlag :: Text -> Maybe Flag)
+
+return []
+tests = $quickCheckAll

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,6 +1,7 @@
 import           Disorder.Core.Main
 
 import qualified Test.Mafia.Cabal.Dependencies
+import qualified Test.Mafia.Cabal.Types
 import qualified Test.Mafia.Hoogle
 import qualified Test.Mafia.Package
 import qualified Test.Mafia.Process
@@ -9,6 +10,7 @@ main :: IO ()
 main =
   disorderMain [
       Test.Mafia.Cabal.Dependencies.tests
+    , Test.Mafia.Cabal.Types.tests
     , Test.Mafia.Hoogle.tests
     , Test.Mafia.Package.tests
     , Test.Mafia.Process.tests


### PR DESCRIPTION
Usage:

``` shell
$ mafia build -fmyflag   # myflag on
$ mafia build -f+myflag  # myflag on
$ mafia build -f-myflag  # myflag off
```

This is to fix https://github.com/ambiata/ambiata-cli/pull/39
