### PR TITLE
Use temporary file to store sdist source list

### DIFF
--- a/src/Mafia/Cabal/Dependencies.hs
+++ b/src/Mafia/Cabal/Dependencies.hs
@@ -38,7 +38,6 @@ import           Mafia.Process
 import           P
 
 import           System.IO (IO)
-import           System.IO.Temp (withSystemTempDirectory)
 
 import           X.Control.Monad.Trans.Either
 
@@ -113,11 +112,10 @@ calculateInstallPlan flags spkgs = do
   (_ :: GhcVersion) <- firstT CabalGhcError getGhcVersion -- check ghc is on the path
   checkCabalVersion
 
-  EitherT . withSystemTempDirectory "mafia-deps-" $ \tmp0 -> runEitherT $ do
+  withSystemTempDirectory "mafia-deps-" $ \tmp -> do
     dir <- getCurrentDirectory
 
-    let tmp   = T.pack tmp0
-        cabal = cabalFrom dir (Just (tmp </> "sandbox.config"))
+    let cabal = cabalFrom dir (Just (tmp </> "sandbox.config"))
 
     Hush <- cabal "sandbox" ["init", "--sandbox", tmp]
 

--- a/src/Mafia/Cabal/Types.hs
+++ b/src/Mafia/Cabal/Types.hs
@@ -201,6 +201,7 @@ data CabalError =
   | CabalSandboxConfigFieldNotFound SandboxConfigFile Text
   | CabalInstallIsNotReferentiallyTransparent
   | CabalSDistFailed Directory
+  | CabalSDistFailedCouldNotReadFile Directory File
   | CabalReinstallsDetected [PackagePlan]
   | CabalCouldNotReadPackageId File
   | CabalCouldNotParseVersion Text
@@ -242,6 +243,10 @@ renderCabalError = \case
 
   CabalSDistFailed dir ->
     "Failed to run 'cabal sdist' for source package: " <> dir
+
+  CabalSDistFailedCouldNotReadFile dir path ->
+    "Failed to run 'cabal sdist' for source package: " <> dir <> "\n" <>
+    "Could not read file: " <> path
 
   CabalCouldNotReadPackageId cabalFile ->
     "Failed to read package-id from: " <> cabalFile

--- a/test/Test/IO/Mafia/Chaos.hs
+++ b/test/Test/IO/Mafia/Chaos.hs
@@ -34,7 +34,6 @@ import           Mafia.Process (call_, callFrom)
 import           P
 
 import           System.IO (IO, print)
-import           System.IO.Temp (withSystemTempDirectory)
 
 import           Test.QuickCheck (Arbitrary(..), Gen, Property, Testable(..))
 import           Test.QuickCheck (forAllProperties)
@@ -282,7 +281,7 @@ bracketDirectory io = bracket getCurrentDirectory setCurrentDirectory (const io)
 
 withTempDirectory :: Testable a => (Directory -> EitherT ChaosError IO a) -> Property
 withTempDirectory io = testIO . bracketDirectory $ do
-  result  <- withSystemTempDirectory "mafia.chaos" (runEitherT . io . T.pack)
+  result  <- runEitherT $ withSystemTempDirectory "mafia.chaos" io
   case result of
     Left  err -> return (QC.counterexample (show err) False)
     Right x   -> return (property x)


### PR DESCRIPTION
This also puts `withSystemTempDirectory` in the `Mafia.IO` module, replacing all the usages of the `[Char]` variant.

/cc @markhibberd
