### PR TITLE
'mafia depends' now supports searching for a specific package

### DIFF
--- a/src/Mafia/Cabal/Dependencies.hs
+++ b/src/Mafia/Cabal/Dependencies.hs
@@ -2,9 +2,11 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Mafia.Cabal.Dependencies
-  ( findDependencies
+  ( filterPackages
+  , findDependencies
   , flagArg
 
     -- exported for testing
@@ -40,6 +42,22 @@ import           P
 import           System.IO (IO)
 
 import           X.Control.Monad.Trans.Either
+
+------------------------------------------------------------------------
+
+filterPackages :: PackageName -> [Package] -> [Package]
+filterPackages name pkgs =
+  mapMaybe (filterPackage name) pkgs
+
+filterPackage :: PackageName -> Package -> Maybe Package
+filterPackage name = \case
+  Package ref deps hash
+    | name == pkgName (refId ref) ->
+      Just (Package ref [] hash)
+    | deps'@(_:_) <- filterPackages name deps ->
+      Just (Package ref deps' hash)
+    | otherwise ->
+      Nothing
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
Usage:

```
~/src/ambiata/ambiata-cli $ mafia depends psqueues --tree
scotty-0.11.0
 └─╼ warp-3.2.2
      └─╼ http2-1.4.4
           └─╼ psqueues-0.2.1.0
```

```
~/src/ambiata/ambiata-cli $ mafia depends ini --tree
amazonka-1.3.2.1
 └─╼ ini-0.3.3
ambiata-mismi-core-0.0.1-bd1a38fde4335c0b492dc6086b4142d1461e986a
 └─╼ amazonka-1.3.2.1
      └─╼ ini-0.3.3
ambiata-mismi-core-test-0.0.1-3963a08c240b1220eca9ec5f24944d43410f1bbf
 ├─╼ amazonka-1.3.2.1
 │    └─╼ ini-0.3.3
 └─╼ ambiata-mismi-core-0.0.1-bd1a38fde4335c0b492dc6086b4142d1461e986a
      └─╼ amazonka-1.3.2.1
           └─╼ ini-0.3.3
ambiata-mismi-s3-0.0.1-bf991362482a32079d921f51334591c6073ebf81
 ├─╼ amazonka-1.3.2.1
 │    └─╼ ini-0.3.3
 └─╼ ambiata-mismi-core-0.0.1-bd1a38fde4335c0b492dc6086b4142d1461e986a
      └─╼ amazonka-1.3.2.1
           └─╼ ini-0.3.3
ambiata-mismi-s3-test-0.0.1-87933826b4223535add2caa61157791fe5fa8321
 ├─╼ amazonka-1.3.2.1
 │    └─╼ ini-0.3.3
 ├─╼ ambiata-mismi-core-0.0.1-bd1a38fde4335c0b492dc6086b4142d1461e986a
 │    └─╼ amazonka-1.3.2.1
 │         └─╼ ini-0.3.3
 ├─╼ ambiata-mismi-core-test-0.0.1-3963a08c240b1220eca9ec5f24944d43410f1bbf
 │    ├─╼ amazonka-1.3.2.1
 │    │    └─╼ ini-0.3.3
 │    └─╼ ambiata-mismi-core-0.0.1-bd1a38fde4335c0b492dc6086b4142d1461e986a
 │         └─╼ amazonka-1.3.2.1
 │              └─╼ ini-0.3.3
 └─╼ ambiata-mismi-s3-0.0.1-bf991362482a32079d921f51334591c6073ebf81
      ├─╼ amazonka-1.3.2.1
      │    └─╼ ini-0.3.3
      └─╼ ambiata-mismi-core-0.0.1-bd1a38fde4335c0b492dc6086b4142d1461e986a
           └─╼ amazonka-1.3.2.1
                └─╼ ini-0.3.3
ini-0.3.3
```

/cc @nhibberd
