### PR TITLE
Accidentally O(scary)

### DIFF
--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -29,6 +29,7 @@ library
                     , exceptions                      == 0.8.*
                     , filelock                        == 0.1.*
                     , filepath                        == 1.4.*
+                    , parallel                        == 3.2.*
                     , process                         == 1.2.*
                     , tar                             == 0.4.*
                     , temporary                       == 1.2.*

--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -9,7 +9,6 @@ import           Control.Concurrent (setNumCapabilities)
 import           Control.Monad.IO.Class (MonadIO(..))
 
 import           Data.ByteString (ByteString)
-import qualified Data.List as List
 import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
@@ -182,7 +181,7 @@ pDependsUI =
 
 pPackageName :: Parser PackageName
 pPackageName =
-  fmap PackageName . argument textRead $
+  fmap mkPackageName . argument textRead $
        metavar "PACKAGE"
     <> help "Only include packages in the output which depend on this package."
 
@@ -255,7 +254,7 @@ mafiaHash = do
 mafiaDepends :: DependsUI -> Maybe PackageName -> [Flag] -> EitherT MafiaError IO ()
 mafiaDepends ui mpkg flags = do
   sdeps <- Set.toList <$> firstT MafiaInitError getSourceDependencies
-  deps <- List.sort <$> firstT MafiaCabalError (findDependencies flags sdeps)
+  deps <- firstT MafiaCabalError (findDependencies flags sdeps)
   let
     deps' = maybe id filterPackages mpkg $ deps
   case ui of

--- a/src/Mafia/Cabal/Package.hs
+++ b/src/Mafia/Cabal/Package.hs
@@ -60,7 +60,7 @@ readPackageId :: MonadIO m => File -> m (Maybe PackageId)
 readPackageId cabalFile = do
   text <- fromMaybe T.empty `liftM` readUtf8 cabalFile
 
-  let findName    = fmap PackageName   . findField "name"
+  let findName    = fmap mkPackageName . findField "name"
       findVersion = (parseVersion =<<) . findField "version"
 
   let lines   = fmap T.words (T.lines text)

--- a/src/Mafia/Tree.hs
+++ b/src/Mafia/Tree.hs
@@ -5,7 +5,8 @@ module Mafia.Tree (
     renderTree
   ) where
 
-import qualified Data.List as List
+import           Data.Set (Set)
+import qualified Data.Set as Set
 import qualified Data.Text.Lazy as Lazy
 
 import           Mafia.Cabal
@@ -31,7 +32,7 @@ renderTree' mindent loc = \case
   Package ref deps _ ->
     let
       sorted =
-        List.sort deps
+        Set.toList deps
 
       branch
         | mindent == Nothing =
@@ -57,6 +58,6 @@ renderTree' mindent loc = \case
       Lazy.fromStrict (renderPackageRef ref) <>
       Lazy.concat (mapLoc (\l d -> "\n" <> renderTree' tindent l d) sorted)
 
-renderTree :: [Package] -> Lazy.Text
+renderTree :: Set Package -> Lazy.Text
 renderTree =
-  Lazy.unlines . mapLoc (renderTree' Nothing)
+  Lazy.unlines . mapLoc (renderTree' Nothing) . Set.toList

--- a/test/Test/Mafia/Arbitrary.hs
+++ b/test/Test/Mafia/Arbitrary.hs
@@ -21,7 +21,7 @@ import           Test.QuickCheck.Instances ()
 instance Arbitrary PackageName where
   arbitrary = do
     name <- T.intercalate "-" <$> listOf1 (elements muppets)
-    pure (PackageName name)
+    pure (mkPackageName name)
 
 instance Arbitrary Version where
   arbitrary =


### PR DESCRIPTION
Sorry everyone, I'm an idiot :(

The hashes will change in this version because I'm now storing package dependencies in a `Set Package` like I should have been doing all along. I think I didn't do this originally because I was just using the default derived instance of `Ord` for `Package` which needed to compare all of a packages dependencies as part of the ordering. Now I have a custom instance which only compares the `PackageRef` and the `Hash`.

This improves the time to calculate transitive dependencies on `hydra-daemon` from ~20-30 mins -> 16 seconds on my machine.

The performance improvements include:
- Not constructing a `Data.CaseInsenitive.CI` for every `Ord` comparison (biggest win)
- Keep packages stored in a `Set` so we don't need to keep reconstructing it to do unions
- Parallel map
- Strictify/unpack fields

/cc @markhibberd 
