### PR TITLE
Use the newest available installed mafia to bootstrap

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,13 +1,53 @@
 #!/bin/sh -eu
 
-git submodule update --init
+#
+# List the version and path to all the installed versions of mafia.
+#
+installed_mafia_versions () {
+  for MAFIA in $(find $HOME/.ambiata/mafia/bin -maxdepth 1 -type f -name 'mafia-*' -exec test -x {} \; -print); do
+    MAFIA_VERSION=$($MAFIA --version)
+    echo "$MAFIA_VERSION $MAFIA"
+  done
+}
 
-cabal sandbox init
+#
+# Find the latest version of mafia which is currently installed.
+#
+latest_mafia () {
+  LATEST=$(installed_mafia_versions | sort --reverse | head -1 | cut -d ' ' -f 2)
+  if [ -z "$LATEST" ]; then
+    return 1
+  else
+    echo "$LATEST"
+  fi
+}
 
-CABAL_SOURCES=$(find lib -maxdepth 4 ! -path lib/\*/bin/\* ! -path lib/\*/lib/\* -name \*.cabal | xargs -L 1 dirname)
-for CABAL_SOURCE in $CABAL_SOURCES; do
-  cabal sandbox add-source -- $CABAL_SOURCE
-done
+#
+# Build using the latest installed version of mafia.
+#
+mafia_build () {
+  MAFIA=$(latest_mafia) || return 1
+  $MAFIA update
+  $MAFIA build
+}
 
-cabal update
-cabal install
+#
+# Build using cabal.
+#
+cabal_build () {
+  git clean -xdf
+  git submodule update --init
+
+  cabal sandbox init
+
+  CABAL_SOURCES=$(find lib -maxdepth 4 ! -path lib/\*/bin/\* ! -path lib/\*/lib/\* -name \*.cabal | xargs -L 1 dirname)
+  for CABAL_SOURCE in $CABAL_SOURCES; do
+    cabal sandbox add-source -- $CABAL_SOURCE
+  done
+
+  cabal update
+  cabal install --only-dependencies
+  cabal build
+}
+
+mafia_build || cabal_build

--- a/script/mafia
+++ b/script/mafia
@@ -87,7 +87,7 @@ exec_mafia () {
 
         bin/bootstrap ) || exit $?
 
-      cp "$MAFIA_TEMP/mafia/.cabal-sandbox/bin/mafia" "$MAFIA_PATH_TEMP"
+      cp "$MAFIA_TEMP/mafia/dist/build/mafia/mafia" "$MAFIA_PATH_TEMP"
       chmod +x "$MAFIA_PATH_TEMP"
       mv "$MAFIA_PATH_TEMP" "$MAFIA_PATH"
     }


### PR DESCRIPTION
This changes the bootstrap script used when building a version of mafia you don't have yet.

The bootstrap script will now find the latest available version of mafia, and use that to build instead of cabal, so that we can benefit from the global cache.

If for some reason this fails, it will do a `git clean -xdf` and try the old cabal method of building.

The contract we are assuming here, is that for all mafia versions, `mafia upgrade && mafia build` will cause an executable to be produced at `dist/build/mafia/mafia`.

/cc @markhibberd @charleso 
