### PR TITLE
mafia install <package>

### DIFF
--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -47,6 +47,7 @@ library
 
   exposed-modules:
                     BuildInfo_ambiata_mafia
+                    Mafia.Bin
                     Mafia.Cabal
                     Mafia.Cabal.Dependencies
                     Mafia.Cabal.Index

--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -323,7 +323,7 @@ mafiaQuick flags extraIncludes paths = do
 
 mafiaWatch :: [Flag] -> [GhciInclude] -> File -> [Argument] -> EitherT MafiaError IO ()
 mafiaWatch flags extraIncludes path extraArgs = do
-  ghcidExe <- bimapT MafiaInstallError (</> "ghcid") $ installBinary (ipackageId "ghcid" [0, 5])
+  ghcidExe <- bimapT MafiaBinError (</> "ghcid") $ installBinary (ipackageId "ghcid" [0, 5])
   args <- ghciArgs extraIncludes [path]
   initMafia DisableProfiling flags
   exec MafiaProcessError ghcidExe $ [ "-c", T.unwords ("ghci" : args) ] <> extraArgs
@@ -336,7 +336,7 @@ mafiaHoogle args = do
 
 mafiaInstall :: InstallPackage -> EitherT MafiaError IO ()
 mafiaInstall ipkg =
-  liftIO . T.putStrLn =<< firstT MafiaInstallError (installBinary ipkg)
+  liftIO . T.putStrLn =<< firstT MafiaBinError (installBinary ipkg)
 
 ghciArgs :: [GhciInclude] -> [File] -> EitherT MafiaError IO [Argument]
 ghciArgs extraIncludes paths = do
@@ -389,7 +389,7 @@ initMafia prof flags = do
 
   let ensureExeOnPath' e pkg =
         lookupEnv e >>= mapM_ (\b -> when (b == "true") $ ensureExeOnPath pkg)
-  firstT MafiaInstallError $ ensureExeOnPath' "MAFIA_HAPPY" (ipackageId "happy" [1, 19, 5])
-  firstT MafiaInstallError $ ensureExeOnPath' "MAFIA_ALEX" (ipackageId "alex" [3, 1, 6])
-  firstT MafiaInstallError $ ensureExeOnPath' "MAFIA_CPPHS" (ipackageId "cpphs" [1, 19, 3])
+  firstT MafiaBinError $ ensureExeOnPath' "MAFIA_HAPPY" (ipackageId "happy" [1, 19, 5])
+  firstT MafiaBinError $ ensureExeOnPath' "MAFIA_ALEX" (ipackageId "alex" [3, 1, 6])
+  firstT MafiaBinError $ ensureExeOnPath' "MAFIA_CPPHS" (ipackageId "cpphs" [1, 19, 3])
   firstT MafiaInitError $ initialize (Just prof) (Just flags)

--- a/src/Mafia/Bin.hs
+++ b/src/Mafia/Bin.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+module Mafia.Bin
+  ( installBinary
+  , ensureExeOnPath
+  ) where
+
+import           Control.Monad.IO.Class (MonadIO(..))
+
+import qualified Data.Text as T
+
+import           Mafia.Home
+import           Mafia.IO
+import           Mafia.Install
+import           Mafia.Package
+import           Mafia.Path
+import           P
+
+import           System.IO (IO)
+import           System.Posix.Files (createSymbolicLink)
+
+import           X.Control.Monad.Trans.Either (EitherT)
+
+
+-- | Installs a given cabal package at a specific version and return a directory containing all executables
+installBinary :: PackageId -> EitherT InstallError IO Directory
+installBinary pid = do
+  bin <- ensureMafiaDir "bin"
+
+  let
+    plink = bin </> renderPackageId pid
+    pdir = plink <> "/"
+    pbin = plink <> "/bin"
+
+  unlessM (doesDirectoryExist pdir) $ do
+    -- if the directory doesn't exist, but there happens to be a file there, we
+    -- must have a dead symlink, so lets remove it and install it again.
+    ignoreIO $ removeFile plink
+
+    pkg <- installPackage pid
+    env <- getPackageEnv
+    let gdir = packageSandboxDir env pkg
+    liftIO $ createSymbolicLink (T.unpack gdir) (T.unpack plink)
+
+  return pbin
+
+ensureExeOnPath :: PackageId -> EitherT InstallError IO ()
+ensureExeOnPath pkg = do
+  dir <- installBinary pkg
+  setEnv "PATH" . maybe dir (\path -> dir <> ":" <> path) =<< lookupEnv "PATH"

--- a/src/Mafia/Cabal/Package.hs
+++ b/src/Mafia/Cabal/Package.hs
@@ -73,6 +73,10 @@ readPackageType cabalFile = do
   text <- liftM (fmap T.toLower . T.lines . fromMaybe T.empty) $ readUtf8 cabalFile
   if any (T.isPrefixOf "library") text then
     return (Just Library)
+  -- Really, really old school .cabal files didn't have a library stanza,
+  -- everything was at the top level, use 'exposed-modules' to detect this.
+  else if any (T.isPrefixOf "exposed-modules") text then
+    return (Just Library)
   else if any (T.isPrefixOf "executable") text then
     return (Just ExecutablesOnly)
   else

--- a/src/Mafia/Cabal/Package.hs
+++ b/src/Mafia/Cabal/Package.hs
@@ -4,7 +4,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Mafia.Cabal.Package
-  ( getPackageId
+  ( PackageType(..)
+  , getPackageId
+  , getPackageType
   , getCabalFile
 
   , SourcePackage(..)
@@ -44,6 +46,39 @@ getCabalFile dir = do
     []     -> return Nothing
     (x:[]) -> return (Just (dir </> x))
     (_:_)  -> return Nothing
+
+------------------------------------------------------------------------
+
+data PackageType =
+    Library
+  | ExecutablesOnly
+    deriving (Eq, Ord, Show)
+
+getPackageType :: Directory -> EitherT CabalError IO PackageType
+getPackageType dir = do
+  mf <- getCabalFile dir
+  case mf of
+    Nothing ->
+      left (CabalFileNotFound dir)
+    Just f -> do
+      mt <- readPackageType f
+      case mt of
+        Nothing  ->
+          left (CabalCouldNotReadPackageType f)
+        Just t ->
+          return t
+
+readPackageType :: MonadIO m => File -> m (Maybe PackageType)
+readPackageType cabalFile = do
+  text <- liftM (fmap T.toLower . T.lines . fromMaybe T.empty) $ readUtf8 cabalFile
+  if any (T.isPrefixOf "library") text then
+    return (Just Library)
+  else if any (T.isPrefixOf "executable") text then
+    return (Just ExecutablesOnly)
+  else
+    return Nothing
+
+------------------------------------------------------------------------
 
 getPackageId :: Directory -> EitherT CabalError IO (Maybe PackageId)
 getPackageId dir = do

--- a/src/Mafia/Cabal/Process.hs
+++ b/src/Mafia/Cabal/Process.hs
@@ -28,7 +28,7 @@ cabal cmd args = call CabalProcessError "cabal" (cmd : args)
 
 cabal_ :: Argument -> [Argument] -> EitherT CabalError IO ()
 cabal_ cmd args = do
-  Pass <- cabal cmd args
+  PassErr <- cabal cmd args
   return ()
 
 cabalFrom

--- a/src/Mafia/Cabal/Sandbox.hs
+++ b/src/Mafia/Cabal/Sandbox.hs
@@ -39,7 +39,7 @@ sandbox cmd args = do
 
 sandbox_ :: Argument -> [Argument] -> EitherT CabalError IO ()
 sandbox_ cmd args = do
-  Pass <- sandbox cmd args
+  PassErr <- sandbox cmd args
   return ()
 
 -- Sandbox initialized if required, this should support sandboxes in parent
@@ -52,8 +52,9 @@ initSandbox = do
 
   dirOk <- doesDirectoryExist sandboxDir
 
-  unless (cfgOk && dirOk) $
-    call_ CabalProcessError "cabal" ["sandbox", "--sandbox", sandboxDir, "init"]
+  unless (cfgOk && dirOk) $ do
+    PassErr <- call CabalProcessError "cabal" ["sandbox", "--sandbox", sandboxDir, "init"]
+    return ()
 
   return sandboxDir
 

--- a/src/Mafia/Cabal/Types.hs
+++ b/src/Mafia/Cabal/Types.hs
@@ -217,8 +217,13 @@ data CabalError =
   | CabalSDistFailed Directory
   | CabalSDistFailedCouldNotReadFile Directory File
   | CabalReinstallsDetected [PackagePlan]
+  | CabalFileNotFound Directory
   | CabalCouldNotReadPackageId File
+  | CabalCouldNotReadPackageType File
   | CabalCouldNotParseVersion Text
+  | CabalNoTopLevelPackage
+  | CabalTopLevelPackageNotFoundInPlan PackageId
+  | CabalMultipleTopLevelPackages [PackageId]
   | CabalInvalidVersion Version MinVersion MaxVersion
   | CabalNotInstalled
     deriving (Show)
@@ -262,11 +267,27 @@ renderCabalError = \case
     "Failed to run 'cabal sdist' for source package: " <> dir <> "\n" <>
     "Could not read file: " <> path
 
+  CabalFileNotFound dir ->
+    "Could not find .cabal file in: " <> dir
+
   CabalCouldNotReadPackageId cabalFile ->
     "Failed to read package-id from: " <> cabalFile
 
+  CabalCouldNotReadPackageType cabalFile ->
+    "Failed to find 'library' or 'executable' stanzas in: " <> cabalFile
+
   CabalCouldNotParseVersion out ->
     "Could not parse or read the cabal-install version number from the following output:\n" <> out
+
+  CabalNoTopLevelPackage ->
+    "No top level package found after parsing install plan"
+
+  CabalTopLevelPackageNotFoundInPlan pid ->
+    "The top level package (" <> renderPackageId pid <> ") was not found in the install plan"
+
+  CabalMultipleTopLevelPackages refs ->
+    "Unexpectedly found multiple top level packages after parsing install plan: " <>
+    T.intercalate ", " (fmap renderPackageId refs)
 
   CabalReinstallsDetected pps ->
     "Cabal's install plan suggested the following reinstalls:" <>

--- a/src/Mafia/Error.hs
+++ b/src/Mafia/Error.hs
@@ -9,6 +9,7 @@ module Mafia.Error
 
 import           Data.Text (Text)
 
+import           Mafia.Bin
 import           Mafia.Cabal.Types
 import           Mafia.Git
 import           Mafia.Hash
@@ -32,6 +33,7 @@ data MafiaError
   | MafiaCabalError CabalError
   | MafiaSubmoduleError SubmoduleError
   | MafiaInstallError InstallError
+  | MafiaBinError BinError
   | MafiaHashError HashError
   | MafiaInitError InitError
   | MafiaParseError Text
@@ -58,6 +60,9 @@ renderMafiaError = \case
 
   MafiaInstallError e ->
     renderInstallError e
+
+  MafiaBinError e ->
+    renderBinError e
 
   MafiaHashError e ->
     renderHashError e

--- a/src/Mafia/Git.hs
+++ b/src/Mafia/Git.hs
@@ -24,7 +24,7 @@ import           Mafia.Process
 
 import           P
 
-import           System.IO (IO)
+import           System.IO (IO, stderr)
 
 import           X.Control.Monad.Trans.Either (EitherT, left)
 
@@ -81,11 +81,12 @@ initSubmodules = do
   nss  <- fmap subName . filter subNeedsInit <$> getSubmodules
   oss  <- fmap subName . filter subOutOfSync <$> getSubmodules
 
-  forM_ nss $ \s ->
-    callFrom_ GitProcessError root "git" ["submodule", "update", "--init", s]
+  forM_ nss $ \s -> do
+    PassErr <- callFrom GitProcessError root "git" ["submodule", "update", "--init", s]
+    return ()
 
   forM_ oss $ \s ->
-    liftIO . T.putStrLn $ "Warning: " <> s <> " is out of sync with the git index"
+    liftIO . T.hPutStrLn stderr $ "Warning: " <> s <> " is out of sync with the git index"
 
 getSubmodules :: EitherT GitError IO [Submodule]
 getSubmodules = do

--- a/src/Mafia/Home.hs
+++ b/src/Mafia/Home.hs
@@ -6,8 +6,6 @@ module Mafia.Home
   ( getMafiaHome
   , getMafiaDir
   , ensureMafiaDir
-  , installBinary
-  , ensureExeOnPath
   ) where
 
 import           Control.Monad.IO.Class (MonadIO(..))
@@ -15,17 +13,9 @@ import           Control.Monad.IO.Class (MonadIO(..))
 import qualified Data.Text as T
 
 import           Mafia.IO
-import           Mafia.Package
 import           Mafia.Path
-import           Mafia.Process
 
 import           P
-
-import           System.FileLock (SharedExclusive (..), lockFile, unlockFile)
-import           System.IO (IO)
-import           System.IO.Temp (withTempDirectory)
-
-import           X.Control.Monad.Trans.Either (EitherT, pattern EitherT, runEitherT, bracketEitherT')
 
 
 getMafiaHome :: MonadIO m => m Directory
@@ -45,38 +35,3 @@ ensureMafiaDir path = do
   path' <- getMafiaDir path
   createDirectoryIfMissing True path'
   return path'
-
--- | Installs a given cabal package at a specific version and return a directory containing all executables
-installBinary :: PackageId -> [PackageId] -> EitherT ProcessError IO Directory
-installBinary package deps = do
-  tmp <- ensureMafiaDir "tmp"
-  let nv = renderPackageId package
-  bin <- ensureMafiaDir "bin"
-  let prefix = bin </> nv
-      path = prefix </> "bin"
-      lock = T.unpack (prefix </> "lock")
-      marker = prefix </> "installed"
-      withLock = bracketEitherT' (liftIO (lockFile lock Exclusive)) (liftIO . unlockFile) . const
-      installArgs p = [ "install", renderPackageId p, "--prefix=" <> prefix ]
-  -- This is to support old versions of mafia that had installed a single executable
-  -- We can remove this at some point
-  -- NOTE: This makes no attempt at being threadsafe
-  whenM (liftIO (doesFileExist prefix)) (removeFile prefix)
-  createDirectoryIfMissing True prefix
-  unlessM (liftIO (doesFileExist marker)) . withLock $
-    unlessM (liftIO (doesFileExist marker)) $
-      EitherT . withTempDirectory (T.unpack tmp) (T.unpack $ nv <> ".") $ \sandboxDir -> runEitherT $ do
-        -- Build the binary and its dependencies in a new sandbox.
-        -- Sandbox necessary as binary's deps could clash with the local project
-        Pass <- callFrom id (T.pack sandboxDir) "cabal" ["sandbox", "init"]
-        -- Install any required executables first
-        for_ deps ensureExeOnPath
-        Pass <- callFrom id (T.pack sandboxDir) "cabal" (installArgs package)
-        writeBytes marker mempty
-        pure ()
-  pure path
-
-ensureExeOnPath :: PackageId -> EitherT ProcessError IO ()
-ensureExeOnPath pkg = do
-  dir <- installBinary pkg []
-  setEnv "PATH" . maybe dir (\path -> dir <> ":" <> path) =<< lookupEnv "PATH"

--- a/src/Mafia/Hoogle.hs
+++ b/src/Mafia/Hoogle.hs
@@ -111,7 +111,7 @@ hoogleCacheDir =
 
 installHoogle :: EitherT MafiaError IO File
 installHoogle =
-  bimapT MafiaInstallError (</> "hoogle") $ do
+  bimapT MafiaBinError (</> "hoogle") $ do
     ensureExeOnPath (ipackageId "happy" [1, 19, 5])
     installBinary (ipackageId "hoogle" [4, 2, 43])
 

--- a/src/Mafia/Hoogle.hs
+++ b/src/Mafia/Hoogle.hs
@@ -112,8 +112,8 @@ hoogleCacheDir =
 installHoogle :: EitherT MafiaError IO File
 installHoogle =
   bimapT MafiaInstallError (</> "hoogle") $ do
-    ensureExeOnPath (packageId "happy" [1, 19, 5])
-    installBinary (packageId "hoogle" [4, 2, 43])
+    ensureExeOnPath (ipackageId "happy" [1, 19, 5])
+    installBinary (ipackageId "hoogle" [4, 2, 43])
 
 hoogleDbFile :: Directory -> PackageId -> File
 hoogleDbFile db pkg =

--- a/src/Mafia/Hoogle.hs
+++ b/src/Mafia/Hoogle.hs
@@ -20,6 +20,7 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
 
+import           Mafia.Bin
 import           Mafia.Cabal
 import           Mafia.Error
 import           Mafia.Home
@@ -110,8 +111,9 @@ hoogleCacheDir =
 
 installHoogle :: EitherT MafiaError IO File
 installHoogle =
-  bimapT MafiaProcessError (</> "hoogle") $
-    installBinary (packageId "hoogle" [4, 2, 43]) [packageId "happy" [1, 19, 5]]
+  bimapT MafiaInstallError (</> "hoogle") $ do
+    ensureExeOnPath (packageId "happy" [1, 19, 5])
+    installBinary (packageId "hoogle" [4, 2, 43])
 
 hoogleDbFile :: Directory -> PackageId -> File
 hoogleDbFile db pkg =

--- a/src/Mafia/Init.hs
+++ b/src/Mafia/Init.hs
@@ -34,7 +34,7 @@ import           Mafia.Submodule
 
 import           P
 
-import           System.IO (IO)
+import           System.IO (IO, stderr)
 
 import           X.Control.Monad.Trans.Either (EitherT, left, hoistEither)
 
@@ -83,7 +83,7 @@ initialize mprofiling mflags = do
 
   clearAddSourceDependencies sandboxDir
 
-  liftIO (T.putStrLn "Checking for changes to dependencies...")
+  liftIO (T.hPutStrLn stderr "Checking for changes to dependencies...")
   previous <- readMafiaState statePath
   current <- getMafiaState (mprofiling <|> fmap msProfiling previous) (mflags <|> fmap msFlags previous)
   hasDist <- liftIO $ doesDirectoryExist "dist"
@@ -93,7 +93,7 @@ initialize mprofiling mflags = do
   let needInstall = previous /= Just current || packages == PackagesBroken
 
   when needInstall $ do
-    liftIO (T.putStrLn "Installing dependencies...")
+    liftIO (T.hPutStrLn stderr "Installing dependencies...")
     let sdeps = Set.toList (msSourceDependencies current)
         flavours = profilingFlavour (msProfiling current)
         flags = msFlags current
@@ -137,7 +137,7 @@ clearAddSourceDependencies sandboxDir = do
 
   for_ deps $ \dep -> do
     dep' <- fromMaybe dep <$> makeRelativeToCurrentDirectory dep
-    liftIO . T.putStrLn $ "Removing add-source dependency: " <> dep'
+    liftIO . T.hPutStrLn stderr $ "Removing add-source dependency: " <> dep'
 
   firstT InitCabalError $ createIndexFile [] sandboxDir
 

--- a/src/Mafia/Install.hs
+++ b/src/Mafia/Install.hs
@@ -126,12 +126,8 @@ installDependencies flavour flags spkgs = do
 
   return ()
 
-installPackage :: PackageId -> EitherT InstallError IO Package
-installPackage (PackageId name ver) =
-  installPackage' name (Just ver)
-
-installPackage' :: PackageName -> Maybe Version -> EitherT InstallError IO Package
-installPackage' name mver = do
+installPackage :: PackageName -> Maybe Version -> EitherT InstallError IO Package
+installPackage name mver = do
   pkg <- firstT InstallCabalError $ findDependenciesForPackage name mver
   installGlobalPackages Vanilla (transitiveOfPackages (Set.singleton pkg))
   return pkg


### PR DESCRIPTION
This allows the use of mafia's global cache for installing executables from Hackage.

Usage:

```
$ mafia install pretty-show
stderr> Building...
stderr> Building...
stdout> /Users/jdoe/.ambiata/mafia/bin/pretty-show/bin
```

Or even better:

```
$ echo "Foo(Bar     (Baz 1 2    3)   )" | $(mafia install pretty-show)/ppsh
Foo (Bar (Baz 1 2 3))
```

It also works with a version number suffix:

```
$ echo "[Max\n1,ML\n2]" | $(mafia install pretty-show-1.6.9)/ppsh
[ Max 1, ML 2 ]
```

The existing `MAFIA_HAPPY`, `MAFIA_ALEX` things now use the global cache as a result of this change.
