### PR TITLE
Add 'mafia lock' for locking down package versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,18 @@ Test this project, by default this runs all test suites.
 Benchmark this project, by default this runs all the benchmarks.
 
 
+### mafia lock
+
+Creates a lock file, which pins the versions of the project's transitive
+dependencies to specific version numbers.
+
+
+### mafia unlock
+
+Deletes the lock file, allowing the Cabal solver to choose new versions
+of packages again.
+
+
 ### mafia repl
 
 Start GHCi via `cabal repl`, by default on the library of the project.

--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -49,6 +49,7 @@ library
                     BuildInfo_ambiata_mafia
                     Mafia.Bin
                     Mafia.Cabal
+                    Mafia.Cabal.Constraint
                     Mafia.Cabal.Dependencies
                     Mafia.Cabal.Index
                     Mafia.Cabal.Package
@@ -65,6 +66,7 @@ library
                     Mafia.IO
                     Mafia.Init
                     Mafia.Install
+                    Mafia.Lock
                     Mafia.Package
                     Mafia.Path
                     Mafia.Process

--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -286,7 +286,7 @@ mafiaHash = do
 mafiaDepends :: DependsUI -> Maybe PackageName -> [Flag] -> EitherT MafiaError IO ()
 mafiaDepends ui mpkg flags = do
   lockFile <- firstT MafiaLockError $ getLockFile =<< getCurrentDirectory
-  constraints <- fmap (fromMaybe []) . firstT MafiaLockError $ readConstraints lockFile
+  constraints <- fmap (fromMaybe []) . firstT MafiaLockError $ readLockFile lockFile
   sdeps <- Set.toList <$> firstT MafiaInitError getSourceDependencies
   local <- firstT MafiaCabalError (findDependenciesForCurrentDirectory flags sdeps constraints)
   let
@@ -339,7 +339,7 @@ mafiaLock flags = do
       left MafiaNoInstallConstraints
     Just constraints -> do
       lockFile <- firstT MafiaLockError $ getLockFile =<< getCurrentDirectory
-      firstT MafiaLockError $ writeConstraints lockFile constraints
+      firstT MafiaLockError $ writeLockFile lockFile constraints
 
 mafiaUnlock :: EitherT MafiaError IO ()
 mafiaUnlock = do

--- a/src/Mafia/Cabal.hs
+++ b/src/Mafia/Cabal.hs
@@ -3,6 +3,7 @@ module Mafia.Cabal
   ( module X
   ) where
 
+import           Mafia.Cabal.Constraint as X
 import           Mafia.Cabal.Dependencies as X
 import           Mafia.Cabal.Index as X
 import           Mafia.Cabal.Package as X

--- a/src/Mafia/Cabal/Constraint.hs
+++ b/src/Mafia/Cabal/Constraint.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Mafia.Cabal.Constraint (
+    Constraint(..)
+  , renderConstraint
+  , parseConstraint
+  , constraintArgs
+
+  , packageRefConstraints
+  , sourcePackageConstraint
+  ) where
+
+import           Data.Text (Text)
+import qualified Data.Text as T
+
+import           Mafia.Cabal.Package
+import           Mafia.Cabal.Types
+import           Mafia.Package
+import           Mafia.Process
+
+import           P
+
+
+data Constraint =
+    ConstraintPackage !PackageId
+  | ConstraintFlag !PackageName !Flag
+    deriving (Eq, Ord, Show)
+
+renderConstraint :: Constraint -> Text
+renderConstraint = \case
+  ConstraintPackage (PackageId name ver) ->
+    unPackageName name <> " == " <> renderVersion ver
+  ConstraintFlag name flag ->
+    unPackageName name <> " " <> renderFlag flag
+
+parseConstraint :: Text -> Either CabalError Constraint
+parseConstraint txt =
+  case T.words txt of
+    [name, "==", ver] ->
+      case parseVersion ver of
+        Nothing ->
+          Left $ CabalCouldNotParseVersion ver
+        Just v ->
+          Right . ConstraintPackage $ PackageId (mkPackageName name) v
+    [name, flag] ->
+      case parseFlag flag of
+        Nothing ->
+          Left $ CabalCouldNotParseFlag flag
+        Just f ->
+          Right $ ConstraintFlag (mkPackageName name) f
+    _ ->
+      Left $ CabalCouldNotParseConstraint txt
+
+constraintArgs :: [Constraint] -> [Argument]
+constraintArgs =
+  concatMap (\c -> ["--constraint", renderConstraint c])
+
+packageRefConstraints :: PackageRef -> [Constraint]
+packageRefConstraints = \case
+  PackageRef pid@(PackageId name _) flags _ ->
+    [ConstraintPackage pid] <> fmap (ConstraintFlag name) flags
+
+sourcePackageConstraint :: SourcePackage -> Constraint
+sourcePackageConstraint =
+  ConstraintPackage . spPackageId

--- a/src/Mafia/Cabal/Types.hs
+++ b/src/Mafia/Cabal/Types.hs
@@ -220,7 +220,10 @@ data CabalError =
   | CabalFileNotFound Directory
   | CabalCouldNotReadPackageId File
   | CabalCouldNotReadPackageType File
+  | CabalCouldNotParseCabalVersion Text
+  | CabalCouldNotParseConstraint Text
   | CabalCouldNotParseVersion Text
+  | CabalCouldNotParseFlag Text
   | CabalNoTopLevelPackage
   | CabalTopLevelPackageNotFoundInPlan PackageId
   | CabalMultipleTopLevelPackages [PackageId]
@@ -276,8 +279,17 @@ renderCabalError = \case
   CabalCouldNotReadPackageType cabalFile ->
     "Failed to find 'library' or 'executable' stanzas in: " <> cabalFile
 
-  CabalCouldNotParseVersion out ->
+  CabalCouldNotParseCabalVersion out ->
     "Could not parse or read the cabal-install version number from the following output:\n" <> out
+
+  CabalCouldNotParseConstraint constraint ->
+    "Could not parse constraint: " <> constraint
+
+  CabalCouldNotParseVersion ver ->
+    "Could not parse package version: " <> ver
+
+  CabalCouldNotParseFlag flag ->
+    "Could not parse flag: " <> flag
 
   CabalNoTopLevelPackage ->
     "No top level package found after parsing install plan"

--- a/src/Mafia/Cabal/Version.hs
+++ b/src/Mafia/Cabal/Version.hs
@@ -30,7 +30,7 @@ getCabalVersion = do
     Left  _         -> left CabalNotInstalled
     Right (Out out) ->
       case parseCabalVersion out of
-        Nothing  -> left (CabalCouldNotParseVersion out)
+        Nothing  -> left (CabalCouldNotParseCabalVersion out)
         Just ver -> return ver
 
 parseCabalVersion :: Text -> Maybe Version

--- a/src/Mafia/Error.hs
+++ b/src/Mafia/Error.hs
@@ -15,6 +15,7 @@ import           Mafia.Git
 import           Mafia.Hash
 import           Mafia.Init
 import           Mafia.Install
+import           Mafia.Lock
 import           Mafia.Process
 import           Mafia.Project
 import           Mafia.Submodule
@@ -36,6 +37,8 @@ data MafiaError
   | MafiaBinError BinError
   | MafiaHashError HashError
   | MafiaInitError InitError
+  | MafiaLockError LockError
+  | MafiaNoInstallConstraints
   | MafiaParseError Text
   | MafiaEntryPointNotFound File
   deriving (Show)
@@ -69,6 +72,12 @@ renderMafiaError = \case
 
   MafiaInitError e ->
     renderInitError e
+
+  MafiaLockError e ->
+    renderLockError e
+
+  MafiaNoInstallConstraints ->
+    "Could not find the dependency constraints calculated during the last install."
 
   MafiaParseError msg ->
     "Parse failed: " <> msg

--- a/src/Mafia/Hash.hs
+++ b/src/Mafia/Hash.hs
@@ -12,9 +12,10 @@ module Mafia.Hash
   , parseHash
 
   , hashHashes
-  , hashFile
   , hashBytes
   , hashText
+  , hashFile
+  , tryHashFile
   ) where
 
 import qualified Crypto.Hash.SHA1 as SHA1
@@ -78,6 +79,11 @@ hashFile file = do
   case mbytes of
     Nothing    -> left (HashFileNotFound file)
     Just bytes -> pure (hashBytes bytes)
+
+tryHashFile :: File -> EitherT HashError IO (Maybe Hash)
+tryHashFile file = do
+  mbytes <- readBytes file
+  pure $ fmap hashBytes mbytes
 
 hashText :: Text -> Hash
 hashText text = do

--- a/src/Mafia/Lock.hs
+++ b/src/Mafia/Lock.hs
@@ -1,0 +1,60 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE LambdaCase #-}
+module Mafia.Lock (
+    LockError(..)
+  , renderLockError
+
+  , getLockFile
+  , readConstraints
+  , writeConstraints
+  ) where
+
+import           Data.Text (Text)
+import qualified Data.Text as T
+
+import           Mafia.Cabal
+import           Mafia.IO
+import           Mafia.Path
+import           Mafia.Project
+
+import           P
+
+import           System.IO (IO)
+
+import           X.Control.Monad.Trans.Either (EitherT, hoistEither)
+
+
+data LockError =
+    LockProjectError ProjectError
+  | LockCabalError CabalError
+    deriving (Show)
+
+renderLockError :: LockError -> Text
+renderLockError = \case
+  LockProjectError e ->
+    renderProjectError e
+  LockCabalError e ->
+    renderCabalError e
+
+getLockFile :: Directory -> EitherT LockError IO File
+getLockFile dir = do
+  project <- firstT LockProjectError $ getProjectName dir
+  return $ dir </> project <> ".lock"
+
+readConstraints :: File -> EitherT LockError IO (Maybe [Constraint])
+readConstraints file = do
+  mtxt <- readUtf8 file
+  case mtxt of
+    Nothing ->
+      pure Nothing
+    Just txt ->
+      fmap Just .
+      traverse (hoistEither . first LockCabalError . parseConstraint) $
+      T.lines txt
+
+writeConstraints :: File -> [Constraint] -> EitherT LockError IO ()
+writeConstraints file xs = do
+  createDirectoryIfMissing True (takeDirectory file)
+  writeUtf8 file . T.unlines $ fmap renderConstraint xs

--- a/src/Mafia/Project.hs
+++ b/src/Mafia/Project.hs
@@ -40,9 +40,9 @@ renderProjectError = \case
     "Found multiple possible .cabal projects: " <> T.intercalate ", " ps
 
 
-getProjectName :: EitherT ProjectError IO ProjectName
-getProjectName = EitherT $ do
-  entries <- filterM doesFileExist =<< getDirectoryContents "."
+getProjectName :: Directory -> EitherT ProjectError IO ProjectName
+getProjectName dir = EitherT $ do
+  entries <- filterM doesFileExist =<< getDirectoryContents dir
 
   let projects = fmap dropExtension
                . filter ((== ".cabal") . takeExtension)

--- a/src/Mafia/Submodule.hs
+++ b/src/Mafia/Submodule.hs
@@ -92,9 +92,10 @@ getSubmoduleSources = Set.union <$> getConfiguredSources
 
 getConfiguredSources :: EitherT SubmoduleError IO (Set Directory)
 getConfiguredSources = do
+  dir <- getCurrentDirectory
   root <- firstT SubmoduleGitError getProjectRoot
-  name <- firstT SubmoduleProjectError getProjectName
-  cfg  <- readUtf8 (name <> ".submodules")
+  name <- firstT SubmoduleProjectError $ getProjectName dir
+  cfg <- readUtf8 (name <> ".submodules")
   return . Set.fromList
          . fmap (root </>)
          . T.lines

--- a/test/Test/Mafia/Arbitrary.hs
+++ b/test/Test/Mafia/Arbitrary.hs
@@ -28,7 +28,6 @@ instance Eq EqCabalError where
   (==) x y =
     show x == show y
 
-
 instance Arbitrary PackageName where
   arbitrary = do
     name <- T.intercalate "-" <$> listOf1 (elements muppets)

--- a/test/Test/Mafia/Arbitrary.hs
+++ b/test/Test/Mafia/Arbitrary.hs
@@ -9,6 +9,7 @@ import qualified Data.Text as T
 
 import           Disorder.Corpus (muppets, cooking)
 
+import           Mafia.Cabal.Constraint
 import           Mafia.Cabal.Types
 import           Mafia.Package
 
@@ -16,6 +17,16 @@ import           P
 
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
+
+
+newtype EqCabalError =
+  EqCabalError {
+      unCabalError :: CabalError
+    } deriving (Show)
+
+instance Eq EqCabalError where
+  (==) x y =
+    show x == show y
 
 
 instance Arbitrary PackageName where
@@ -68,3 +79,10 @@ instance Arbitrary PackagePlan where
       arbitrary <*>
       arbitrary <*>
       arbitrary
+
+instance Arbitrary Constraint where
+  arbitrary =
+    oneof [
+        ConstraintPackage <$> arbitrary
+      , ConstraintFlag <$> arbitrary <*> arbitrary
+      ]

--- a/test/Test/Mafia/Cabal/Constraint.hs
+++ b/test/Test/Mafia/Cabal/Constraint.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+module Test.Mafia.Cabal.Constraint where
+
+import           Disorder.Core.Tripping (tripping)
+
+import           Mafia.Cabal.Constraint
+
+import           P
+
+import           Test.Mafia.Arbitrary (EqCabalError(..))
+import           Test.QuickCheck
+import           Test.QuickCheck.Instances ()
+
+
+prop_roundtrip_Constraint =
+  tripping renderConstraint (first EqCabalError . parseConstraint)
+
+return []
+tests = $quickCheckAll

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,5 +1,6 @@
 import           Disorder.Core.Main
 
+import qualified Test.Mafia.Cabal.Constraint
 import qualified Test.Mafia.Cabal.Dependencies
 import qualified Test.Mafia.Cabal.Types
 import qualified Test.Mafia.Hoogle
@@ -9,7 +10,8 @@ import qualified Test.Mafia.Process
 main :: IO ()
 main =
   disorderMain [
-      Test.Mafia.Cabal.Dependencies.tests
+      Test.Mafia.Cabal.Constraint.tests
+    , Test.Mafia.Cabal.Dependencies.tests
     , Test.Mafia.Cabal.Types.tests
     , Test.Mafia.Hoogle.tests
     , Test.Mafia.Package.tests


### PR DESCRIPTION
This adds two new commands, `mafia lock` and `mafia unlock`.

`mafia lock` creates a `<project>.lock` file alongside the `<project>.cabal` file which contains the version numbers and flags of all the Hackage packages which were used during the last build. Subsequent builds add all of these constraints to any solving they do. This means that if someone releases a newer version of a locked down package on Hackage, then the newer version will be ignored.

Running `mafia lock` when you already have a `.lock` file can be used to update the `.lock` with any new packages you've added to your `.cabal` file without losing a lock on the existing ones.

`mafia unlock` simply deletes the `.lock` file, allowing Cabal's solver free reign over package choice.

I'm not completely sure whether lock files will be a net positive or negative, would be great to hear peoples thoughts? It certainly could be useful to avoid rebuilds at the present time, given that people are madly upgrading all their packages to support GHC 8.0.

Happy for people to bikeshed the file names and the way it it is invoked. Some package manager / build systems (such as Rust's Cargo) create a lock file automatically when you build. 

For the record, I tried to get Cabal's freeze/unfreeze stuff to work, but there's something about the way we do dependency solving in Mafia that means Cabal just ignores the freeze file which it creates, _shrugs_.

/cc @markhibberd @charleso @thumphries @damncabbage 
