### PR TITLE
Add -rtsopts to profiling builds

### DIFF
--- a/src/Mafia/Init.hs
+++ b/src/Mafia/Init.hs
@@ -154,6 +154,7 @@ profilingArgs = \case
       "--enable-profiling"
     , "--disable-executable-stripping"
     , "--ghc-options=-fprof-auto-top"
+    , "--ghc-options=-rtsopts"
     ]
 
 -- If a user or an older version of mafia has used 'cabal sandbox add-source'


### PR DESCRIPTION
The one I want is `-M` (for debugging heap alloc issues), not aware of any way to enable it on its own - building rtsopts into a profiling build seems pretty harmless.

/cc @jystic 
