### PR TITLE
Resolve symbolic links when looking up MAFIA_HOME

### DIFF
--- a/src/Mafia/Bin.hs
+++ b/src/Mafia/Bin.hs
@@ -18,7 +18,6 @@ module Mafia.Bin
 
 import           Control.Monad.IO.Class (MonadIO(..))
 
-import           Data.Text (Text)
 import qualified Data.Text as T
 
 import           Mafia.Home

--- a/src/Mafia/Cabal/Constraint.hs
+++ b/src/Mafia/Cabal/Constraint.hs
@@ -11,7 +11,6 @@ module Mafia.Cabal.Constraint (
   , sourcePackageConstraint
   ) where
 
-import           Data.Text (Text)
 import qualified Data.Text as T
 
 import           Mafia.Cabal.Package

--- a/src/Mafia/Cabal/Dependencies.hs
+++ b/src/Mafia/Cabal/Dependencies.hs
@@ -27,7 +27,6 @@ import qualified Data.Set as Set
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.String (String)
-import           Data.Text (Text)
 import qualified Data.Text as T
 
 import           Mafia.Cabal.Constraint

--- a/src/Mafia/Cabal/Package.hs
+++ b/src/Mafia/Cabal/Package.hs
@@ -21,7 +21,6 @@ import           Control.Monad.IO.Class (MonadIO(..))
 
 import qualified Data.List as List
 import qualified Data.Set as Set
-import           Data.Text (Text)
 import qualified Data.Text as T
 
 import           Mafia.Cabal.Types

--- a/src/Mafia/Cabal/Sandbox.hs
+++ b/src/Mafia/Cabal/Sandbox.hs
@@ -15,7 +15,6 @@ module Mafia.Cabal.Sandbox
 import           Control.Monad.IO.Class (MonadIO(..))
 
 import qualified Data.List as List
-import           Data.Text (Text)
 import qualified Data.Text as T
 
 import           Mafia.Cabal.Process

--- a/src/Mafia/Cabal/Types.hs
+++ b/src/Mafia/Cabal/Types.hs
@@ -34,7 +34,6 @@ import           Data.Aeson (Value(..), ToJSON(..), FromJSON(..), (.:), (.=), ob
 import           Data.Char (isAlpha)
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Text (Text)
 import qualified Data.Text as T
 
 import           Mafia.Ghc

--- a/src/Mafia/Cabal/Version.hs
+++ b/src/Mafia/Cabal/Version.hs
@@ -8,7 +8,6 @@ module Mafia.Cabal.Version
 
 import           Control.Monad.IO.Class (liftIO)
 
-import           Data.Text (Text)
 import qualified Data.Text as T
 
 import           Mafia.Cabal.Process

--- a/src/Mafia/Error.hs
+++ b/src/Mafia/Error.hs
@@ -7,8 +7,6 @@ module Mafia.Error
   , liftCabal
   ) where
 
-import           Data.Text (Text)
-
 import           Mafia.Bin
 import           Mafia.Cabal.Types
 import           Mafia.Git

--- a/src/Mafia/Ghc.hs
+++ b/src/Mafia/Ghc.hs
@@ -9,7 +9,6 @@ module Mafia.Ghc
   , renderGhcError
   ) where
 
-import           Data.Text (Text)
 import qualified Data.Text as T
 
 import           Mafia.Process

--- a/src/Mafia/Git.hs
+++ b/src/Mafia/Git.hs
@@ -15,7 +15,6 @@ module Mafia.Git
 
 import           Control.Monad.IO.Class (liftIO)
 
-import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 

--- a/src/Mafia/Hash.hs
+++ b/src/Mafia/Hash.hs
@@ -25,7 +25,6 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Lazy as L
-import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 

--- a/src/Mafia/Home.hs
+++ b/src/Mafia/Home.hs
@@ -21,9 +21,12 @@ import           P
 getMafiaHome :: MonadIO m => m Directory
 getMafiaHome = do
   mhome <- lookupEnv "MAFIA_HOME"
-  case mhome of
-    Just home -> return home
-    Nothing   -> (</> T.pack ".ambiata/mafia") `liftM` getHomeDirectory
+  bind canonicalizePath $
+    case mhome of
+      Just home ->
+        return home
+      Nothing ->
+        (</> T.pack ".ambiata/mafia") `liftM` getHomeDirectory
 
 getMafiaDir :: MonadIO m => Directory -> m Directory
 getMafiaDir path = do

--- a/src/Mafia/Hoogle.hs
+++ b/src/Mafia/Hoogle.hs
@@ -15,7 +15,6 @@ import qualified Crypto.Hash as Hash
 import qualified Data.List as L
 import           Data.Map (Map)
 import qualified Data.Map as M
-import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T

--- a/src/Mafia/IO.hs
+++ b/src/Mafia/IO.hs
@@ -60,7 +60,6 @@ import           Control.Monad.Trans.Maybe (MaybeT(..))
 
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as B
-import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import           Data.Time (UTCTime)

--- a/src/Mafia/Init.hs
+++ b/src/Mafia/Init.hs
@@ -21,7 +21,6 @@ import           Data.Aeson (Value(..), ToJSON(..), FromJSON(..), (.:), (.=))
 import qualified Data.ByteString.Lazy as L
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 

--- a/src/Mafia/Install.hs
+++ b/src/Mafia/Install.hs
@@ -26,7 +26,6 @@ import           Data.Char (ord)
 import qualified Data.List as List
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy as TL

--- a/src/Mafia/Lock.hs
+++ b/src/Mafia/Lock.hs
@@ -12,7 +12,6 @@ module Mafia.Lock (
   , writeLockFile
   ) where
 
-import           Data.Text (Text)
 import qualified Data.Text as T
 
 import           Mafia.Cabal

--- a/src/Mafia/Package.hs
+++ b/src/Mafia/Package.hs
@@ -21,7 +21,6 @@ import           Data.Aeson (Value(..), ToJSON(..), FromJSON(..))
 import           Data.CaseInsensitive (CI)
 import qualified Data.CaseInsensitive as CI
 import qualified Data.Char as Char
-import           Data.Text (Text)
 import qualified Data.Text as T
 import           Data.Version (Version (..))
 import qualified Data.Version as Version

--- a/src/Mafia/Path.hs
+++ b/src/Mafia/Path.hs
@@ -21,7 +21,6 @@ module Mafia.Path
   ) where
 
 import qualified Data.List as List
-import           Data.Text (Text)
 import qualified Data.Text as T
 
 import           P

--- a/src/Mafia/Process.hs
+++ b/src/Mafia/Process.hs
@@ -51,7 +51,6 @@ import qualified Data.ByteString.Char8 as B
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.String (String)
-import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 

--- a/src/Mafia/Project.hs
+++ b/src/Mafia/Project.hs
@@ -10,7 +10,6 @@ module Mafia.Project
   , renderProjectError
   ) where
 
-import           Data.Text (Text)
 import qualified Data.Text as T
 
 import           Mafia.IO

--- a/src/Mafia/Submodule.hs
+++ b/src/Mafia/Submodule.hs
@@ -13,7 +13,6 @@ import           Control.Monad.IO.Class (MonadIO(..))
 
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 

--- a/test/Test/IO/Mafia/Chaos.hs
+++ b/test/Test/IO/Mafia/Chaos.hs
@@ -20,7 +20,6 @@ import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 

--- a/test/Test/Mafia/Cabal/Types.hs
+++ b/test/Test/Mafia/Cabal/Types.hs
@@ -4,8 +4,6 @@
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 module Test.Mafia.Cabal.Types where
 
-import           Data.Text (Text)
-
 import           Disorder.Core.Tripping (tripping)
 
 import           Mafia.Cabal.Types


### PR DESCRIPTION
Cabal always uses absolute paths with symlinks resolved when referring to files, so we need to do the same.

This should hopefully fix the bug where we calculate the wrong jenkins hash for the sandbox directory when trying to build happy in a mafia cache that is symlinked to another path.

/cc @nhibberd @markhibberd 
