### PR TITLE
Switch away from deprecated cryptohash package

### DIFF
--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -24,11 +24,12 @@ library
                     , bytestring                      == 0.10.*
                     , case-insensitive                == 1.2.*
                     , containers                      == 0.5.*
-                    , cryptohash                      == 0.11.*
+                    , cryptonite                      == 0.15.*
                     , directory                       == 1.2.*
                     , exceptions                      == 0.8.*
                     , filelock                        == 0.1.*
                     , filepath                        == 1.4.*
+                    , memory                          == 0.12.*
                     , parallel                        == 3.2.*
                     , process                         == 1.2.*
                     , tar                             == 0.4.*

--- a/src/Mafia/Hoogle.hs
+++ b/src/Mafia/Hoogle.hs
@@ -10,18 +10,16 @@ module Mafia.Hoogle
 
 import           Control.Monad.IO.Class (MonadIO(..))
 
-import qualified Crypto.Hash as Hash
-
 import qualified Data.List as L
 import           Data.Map (Map)
 import qualified Data.Map as M
 import qualified Data.Text as T
-import qualified Data.Text.Encoding as T
 import qualified Data.Text.IO as T
 
 import           Mafia.Bin
 import           Mafia.Cabal
 import           Mafia.Error
+import           Mafia.Hash
 import           Mafia.Home
 import           Mafia.IO
 import           Mafia.Init
@@ -80,8 +78,7 @@ hoogleIndex args pkgs = do
   -- 1. Create a unique directory based on all the current packages and ensure the default.hoo
   -- 2. Specify/append all the packages from the global database by using "+$name-$version"
   --    Unfortunately hoogle doesn't like the "-$version" part :(
-  let hash = T.decodeUtf8 . (\(d :: Hash.Digest Hash.SHA1) -> Hash.digestToHexByteString d) . Hash.hash . T.encodeUtf8 .
-        mconcat . fmap renderPackageId $ pkgs
+  let hash = renderHash .  hashText .  mconcat .  fmap renderPackageId $ pkgs
   db <- hoogleCacheDir
   hoogleExe <- installHoogle
   db' <- (\d -> d </> "hoogle" </> hash) <$> liftCabal initSandbox


### PR DESCRIPTION
All the crypto stuff is now in `cryptonite`, depending on `cryptohash` now gives errors like this:

```
src/Mafia/Hoogle.hs:13:18:
    Ambiguous module name ‘Crypto.Hash’:
      it was found in multiple packages:
      cryptonite-0.13 cryptohash-0.11.9
```

/cc @charleso  
