### PR TITLE
GHC 8.0 / Cabal 1.24 Support

### DIFF
--- a/src/Mafia/Cabal/Sandbox.hs
+++ b/src/Mafia/Cabal/Sandbox.hs
@@ -69,8 +69,8 @@ removeSandbox = do
   whenM (doesDirectoryExist dir) $
     removeDirectoryRecursive dir
 
-  -- remvoe sandbox config file
-  whenM (doesFileExist dir) $
+  -- remove sandbox config file
+  whenM (doesFileExist defaultConfig) $
     removeFile defaultConfig
 
   -- remove root sandbox directory if it is now empty

--- a/src/Mafia/Cabal/Version.hs
+++ b/src/Mafia/Cabal/Version.hs
@@ -49,7 +49,7 @@ checkCabalVersion = do
   --   https://github.com/haskell/cabal/commit/c0b3c7f1b6ae7bb7663a2c18578ede95d6a40919
 
   let vmin = Version [1,22,4] []
-      vmax = Version [1,24]   []
+      vmax = Version [1,26]   []
 
   version <- getCabalVersion
 


### PR DESCRIPTION
The `cabal clean` issue turned out to be my bad, I was leaving a `cabal.sandbox.config` file around that it was confused by.

/cc @tmcgilchrist 
