### PR TITLE
Support for detecting and installing build-tools

### DIFF
--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -22,6 +22,7 @@ library
                     , attoparsec                      >= 0.12       && < 0.14
                     , base16-bytestring               == 0.1.*
                     , bytestring                      == 0.10.*
+                    , Cabal                           >= 1.22       && < 1.25
                     , case-insensitive                == 1.2.*
                     , containers                      == 0.5.*
                     , cryptonite                      == 0.15.*

--- a/src/Mafia/Cabal/Dependencies.hs
+++ b/src/Mafia/Cabal/Dependencies.hs
@@ -182,7 +182,7 @@ makeInstallPlan mdir sourcePkgs installArgs = do
   withSystemTempDirectory "mafia-deps-" $ \tmp -> do
     let
       dir = fromMaybe tmp mdir
-      cabal = cabalFrom dir (Just (tmp </> "sandbox.config"))
+      cabal = cabalFrom dir (tmp </> "sandbox.config") []
 
     Hush <- cabal "sandbox" ["init", "--sandbox", tmp]
 
@@ -227,7 +227,7 @@ takeReinstall p =
 
 parseInstallPlan :: Text -> Either CabalError [PackagePlan]
 parseInstallPlan =
-  first (CabalParseError . T.pack) .
+  first (CabalInstallPlanParseError . T.pack) .
   traverse parsePackagePlan .
   List.drop 1 .
   List.dropWhile (/= "In order, the following would be installed:") .

--- a/test/cli/happy/run
+++ b/test/cli/happy/run
@@ -1,0 +1,12 @@
+#!/bin/sh -eux
+
+absolute_path() {
+  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
+MAFIA=$(absolute_path ${1:-./dist/build/mafia/mafia})
+
+MAFIA_TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'mafia')
+trap "rm -rf \"${MAFIA_TEMP}\"" EXIT
+
+MAFIA_HOME=$MAFIA_TEMP $MAFIA install pretty-show


### PR DESCRIPTION
Before trying to build packages which we are installing, mafia will now parse their `.cabal` file and install any build tools (i.e. `happy`, `alex`) which are required and also put them on the `PATH` temporarily.

This means we don't need `MAFIA_HAPPY=true` and friends anymore for the most part. It is still required for bmx itself as this only applies to dependencies, but we can fix easily enough in another PR I think.

It might be that we need some environment variable to control this magic and maybe exclude certain build tools, but I'm not sure what that looks like yet so I'd rather wait until we have a problem, and I'll fix it when it comes up.

/cc @markhibberd @thumphries @charleso @nhibberd @olorin 
