### PR TITLE
Put build-tools on path for current project

### DIFF
--- a/src/Mafia/Hoogle.hs
+++ b/src/Mafia/Hoogle.hs
@@ -108,7 +108,6 @@ hoogleCacheDir =
 installHoogle :: EitherT MafiaError IO File
 installHoogle =
   bimapT MafiaBinError (</> "hoogle") $ do
-    ensureExeOnPath (ipackageId "happy" [1, 19, 5])
     installBinary (ipackageId "hoogle" [4, 2, 43])
 
 hoogleDbFile :: Directory -> PackageId -> File


### PR DESCRIPTION
This is a follow on from the build-tools PR yesterday, doing the same thing for the current project.

It also removes the `MAFIA_HAPPY` like env vars are they are no longer required.

/cc @thumphries 
