### PR TITLE
Better error messages for 'cabal unpack' and 'cabal sdist' failures

### DIFF
--- a/src/Mafia/Cabal/Package.hs
+++ b/src/Mafia/Cabal/Package.hs
@@ -283,9 +283,11 @@ hashSourcePackage dir = do
 
   sdistFiles <- withSystemTempDirectory "mafia-sdist-" $ \tmp -> do
     let
-      sdistError _ = CabalSDistFailed rdir
       path = tmp </> "sources.txt"
-    OutErr (_ :: Text) _ <- callFrom sdistError dir "cabal" ["sdist", "--list-sources=" <> path]
+
+    capture (CabalSDistFailed rdir) $
+      callFrom (CabalSDistDisaster rdir) dir "cabal" ["sdist", "--list-sources=" <> path]
+
     mfile <- readUtf8 path
     case mfile of
       Nothing ->

--- a/src/Mafia/Cabal/Types.hs
+++ b/src/Mafia/Cabal/Types.hs
@@ -217,7 +217,8 @@ data CabalError =
   | CabalSandboxConfigFileNotFound SandboxConfigFile
   | CabalSandboxConfigFieldNotFound SandboxConfigFile Text
   | CabalInstallIsNotReferentiallyTransparent
-  | CabalSDistFailed Directory
+  | CabalSDistDisaster Directory ProcessError
+  | CabalSDistFailed Directory (OutErrCode Text)
   | CabalSDistFailedCouldNotReadFile Directory File
   | CabalReinstallsDetected [PackagePlan]
   | CabalFileNotFound Directory
@@ -276,8 +277,13 @@ renderCabalError = \case
   CabalInstallIsNotReferentiallyTransparent ->
     "The impossible happened, cabal-install gave different answers on subsequent dry runs"
 
-  CabalSDistFailed dir ->
-    "Failed to run 'cabal sdist' for source package: " <> dir
+  CabalSDistDisaster dir err ->
+    "Failed to run 'cabal sdist' for source package: " <> dir <> "\n" <>
+    renderProcessError err
+
+  CabalSDistFailed dir out ->
+    "Failed to run 'cabal sdist' for source package: " <> dir <> "\n" <>
+    renderOutErrCode out
 
   CabalSDistFailedCouldNotReadFile dir path ->
     "Failed to run 'cabal sdist' for source package: " <> dir <> "\n" <>


### PR DESCRIPTION
We occasionally get errors due to `cabal unpack` or `cabal sdist` failing on the build bots, the existing errors weren't very useful as they did not include the output from cabal itself. This fixes that, now when `cabal unpack` fails you get something like:

```
Failed to unpack bifunctors-5.2.1 to /var/folders/ym/gt38kky12mng7gp0kvqqg5s40000gn/T/mafia-build-tools-72310
Process failed with exit code: 1
/foo: createDirectory: permission denied (Permission denied)
```

and when `cabal sdist` fails you get something like:

```
Failed to run 'cabal sdist' for source package: lib/p
Process failed with exit code: 1
cabal: Error: Could not find module: P.Foo.Bar.Baz with any suffix:
["gc","chs","hsc","x","y","ly","cpphs","hs","lhs"]
```

/cc @erikd-ambiata @nhibberd @charleso @olorin 
