### PR TITLE
Only run 'cabal update' in bootstrap if cache is older than a day

### DIFF
--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,5 +1,20 @@
 #!/bin/sh -eu
 
+#
+# Run 'cabal update' if the cache is older than a day.
+#
+
+CACHE="$HOME/.cabal/packages/hackage.haskell.org/00-index.cache"
+
+if ! test -f "$CACHE" || find "$CACHE" -type f -mtime +1 | grep -q 00-index; then
+  cabal update
+fi
+
+
+#
+# Install dependencies and build mafia in a sandbox.
+#
+
 git submodule update --init
 
 cabal sandbox init
@@ -9,5 +24,4 @@ for CABAL_SOURCE in $CABAL_SOURCES; do
   cabal sandbox add-source -- $CABAL_SOURCE
 done
 
-cabal update
-cabal install
+cabal install --reorder-goals --max-backjumps=-1


### PR DESCRIPTION
Despite the fixes we made to ensure that build bots run `cabal update` on boot so they always have a valid package list, we're still seeing problems.

I suspect that it is _always_ bad to run `cabal update` at the same time as something else is running `cabal install`. Perhaps `cabal update` deletes and recreates the cache file no matter what, even if it doesn't update the package list, and so when the other process is running `cabal install` it reads an empty file and thinks there are no packages available.

This change makes it so that the mafia bootstrap script works the same way as `mafia update`. Specifically, it only calls `cabal update` if the cache is older than a day. This should mean that we never run `cabal update` on build bots.

I also figured it can't hurt to switch on `--reorder-goals --max-backjumps=-1` for installing mafia's own dependencies.

/cc @nhibberd @charleso @erikd-ambiata @olorin 
