### PR TITLE
WIP gc

### DIFF
--- a/mafia-gc/Setup.hs
+++ b/mafia-gc/Setup.hs
@@ -1,0 +1,106 @@
+#!/usr/bin/env runhaskell
+
+import           Data.Char (isDigit, toLower)
+import           Data.Function (on)
+import           Data.List (intercalate, sortBy)
+import           Data.Monoid ((<>))
+import           Data.Version (showVersion)
+
+import           Distribution.InstalledPackageInfo
+import           Distribution.PackageDescription
+import           Distribution.Simple
+import           Distribution.Simple.Setup (BuildFlags(..), ReplFlags(..), TestFlags(..), fromFlag)
+import           Distribution.Simple.LocalBuildInfo
+import           Distribution.Simple.PackageIndex
+import           Distribution.Simple.BuildPaths (autogenModulesDir)
+import           Distribution.Simple.Utils (createDirectoryIfMissingVerbose, rewriteFile, rawSystemStdout)
+import           Distribution.Verbosity
+
+main :: IO ()
+main =
+  let hooks = simpleUserHooks
+   in defaultMainWithHooks hooks {
+     preConf = \args flags -> do
+       createDirectoryIfMissingVerbose silent True "gen"
+       (preConf hooks) args flags
+   , sDistHook  = \pd mlbi uh flags -> do
+       genBuildInfo silent pd
+       (sDistHook hooks) pd mlbi uh flags
+   , buildHook = \pd lbi uh flags -> do
+       genBuildInfo (fromFlag $ buildVerbosity flags) pd
+       genDependencyInfo (fromFlag $ buildVerbosity flags) pd lbi
+       (buildHook hooks) pd lbi uh flags
+   , replHook = \pd lbi uh flags args -> do
+       genBuildInfo (fromFlag $ replVerbosity flags) pd
+       genDependencyInfo (fromFlag $ replVerbosity flags) pd lbi
+       (replHook hooks) pd lbi uh flags args
+   , testHook = \args pd lbi uh flags -> do
+       genBuildInfo (fromFlag $ testVerbosity flags) pd
+       genDependencyInfo (fromFlag $ testVerbosity flags) pd lbi
+       (testHook hooks) args pd lbi uh flags
+   }
+
+genBuildInfo :: Verbosity -> PackageDescription -> IO ()
+genBuildInfo verbosity pkg = do
+  createDirectoryIfMissingVerbose verbosity True "gen"
+  let (PackageName pname) = pkgName . package $ pkg
+      version = pkgVersion . package $ pkg
+      name = "BuildInfo_" ++ (map (\c -> if c == '-' then '_' else c) pname)
+      targetHs = "gen/" ++ name ++ ".hs"
+      targetText = "gen/version.txt"
+  t <- timestamp verbosity
+  gv <- gitVersion verbosity
+  let v = showVersion version
+  let buildVersion = intercalate "-" [v, t, gv]
+  rewriteFile targetHs $ unlines [
+      "module " ++ name ++ " where"
+    , "import Prelude"
+    , "data RuntimeBuildInfo = RuntimeBuildInfo { buildVersion :: String, timestamp :: String, gitVersion :: String }"
+    , "buildInfo :: RuntimeBuildInfo"
+    , "buildInfo = RuntimeBuildInfo \"" ++ v ++ "\" \"" ++ t ++ "\" \"" ++ gv ++ "\""
+    , "buildInfoVersion :: String"
+    , "buildInfoVersion = \"" ++ buildVersion ++ "\""
+    ]
+  rewriteFile targetText buildVersion
+
+genDependencyInfo :: Verbosity -> PackageDescription -> LocalBuildInfo -> IO ()
+genDependencyInfo verbosity pkg info = do
+  let
+    (PackageName pname) = pkgName . package $ pkg
+    name = "DependencyInfo_" ++ (map (\c -> if c == '-' then '_' else c) pname)
+    targetHs = autogenModulesDir info ++ "/" ++ name ++ ".hs"
+    render p =
+      let
+        n = unPackageName $ pkgName p
+        v = intercalate "." . fmap show . versionBranch $ pkgVersion p
+      in
+       n ++ "-" ++ v
+    deps = fmap (render . sourcePackageId) . allPackages $ installedPkgs info
+    sdeps = sortBy (compare `on` fmap toLower) deps
+    strs = flip fmap sdeps $ \d -> "\"" ++ d ++ "\""
+
+  createDirectoryIfMissingVerbose verbosity True (autogenModulesDir info)
+
+  rewriteFile targetHs $ unlines [
+      "module " ++ name ++ " where"
+    , "import Prelude"
+    , "dependencyInfo :: [String]"
+    , "dependencyInfo = [\n    " ++ intercalate "\n  , " strs ++ "\n  ]"
+    ]
+
+gitVersion :: Verbosity -> IO String
+gitVersion verbosity = do
+  ver <- rawSystemStdout verbosity "git" ["log", "--pretty=format:%h", "-n", "1"]
+  notModified <- ((>) 1 . length) `fmap` rawSystemStdout verbosity "git" ["status", "--porcelain"]
+  return $ ver ++ if notModified then "" else "-M"
+
+timestamp :: Verbosity -> IO String
+timestamp verbosity =
+  rawSystemStdout verbosity "date" ["+%Y%m%d%H%M%S"] >>= \s ->
+    case splitAt 14 s of
+      (d, n : []) ->
+        if (length d == 14 && filter isDigit d == d)
+          then return d
+          else fail $ "date has failed to produce the correct format [" <> s <> "]."
+      _ ->
+        fail $ "date has failed to produce a date long enough [" <> s <> "]."

--- a/mafia-gc/mafia-gc.cabal
+++ b/mafia-gc/mafia-gc.cabal
@@ -1,0 +1,34 @@
+name:                  mafia-gc
+version:               0.0.1
+license:               AllRightsReserved
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2015 Ambiata.
+synopsis:              mafia-gc
+category:              Build
+cabal-version:         >= 1.8
+build-type:            Custom
+description:           Garbage collection for the mafia cache
+
+executable mafia-gc
+  build-depends:
+                          base                        >= 4.6        && < 5
+                        , ambiata-p
+                        , transformers
+                        , containers
+                        , directory
+                        , conduit                     == 1.2.*
+                        , find-conduit                == 0.4.*
+                        , resourcet
+                        , unix
+                        , filepath
+
+  ghc-options:          -Wall
+  if impl(ghc >= 8.0)
+    ghc-options:        -fno-warn-redundant-constraints
+
+  hs-source-dirs:
+                       gen
+
+  main-is:
+                       ../main/mafia-gc.hs

--- a/mafia-gc/main/mafia-gc.hs
+++ b/mafia-gc/main/mafia-gc.hs
@@ -1,0 +1,119 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+module Main where
+
+
+import           Control.Monad.IO.Class  (MonadIO(..))
+import           Control.Monad.Trans.Resource  (MonadResource(..), runResourceT)
+
+import           Data.Conduit (Consumer, Producer, ($$), (=$=))
+import qualified Data.Conduit.Find as F
+import qualified Data.Conduit.List as CL
+import           Data.Set  (Set)
+import qualified Data.Set as S
+
+import           P
+
+import           System.Directory (removeDirectoryRecursive)
+import           System.Environment  (getArgs)
+import           System.FilePath.Posix  ((</>), takeDirectory, takeFileName)
+import           System.IO  (FilePath, IO, putStrLn)
+import qualified System.Posix.Files as U
+
+
+data GcRun
+  = ListUsed
+  | ListUnused
+  | RmRfUnused
+
+
+main :: IO ()
+main = do
+  args <- getArgs
+  case args of
+    (x:y:_) ->
+      -- TODO canonicalise dirs
+      run ListUnused x y
+    _ ->
+      putStrLn "Usage: mafia-gc MAFIA_DIR DIR"
+
+run :: GcRun -> FilePath -> FilePath -> IO ()
+run runt mafia dir = do
+  let cache = mafia </> "packages"
+      bins = mafia </> "bin"
+  used <- runResourceT (findLinkedPackages cache dir $$ foldSet)
+  binUsed <- runResourceT (findLinkedBinaries cache bins $$ foldSet)
+  let allUsed = S.union used binUsed
+      getUnused sink = runResourceT $
+            findAllPackages cache
+        =$= CL.filter (\f -> not (S.member f allUsed))
+        =$= CL.filter (\f -> not (S.member (takeFileName f) specialFiles))
+         $$ sink
+  case runt of
+    ListUsed ->
+      for_ (S.toList allUsed) putStrLn
+
+    ListUnused ->
+      getUnused (CL.mapM_ (liftIO . putStrLn))
+
+    RmRfUnused -> do
+      ded <- getUnused CL.consume
+      for_ ded removePackage
+      putStrLn $ "Deleted " <> show (length ded) <> " packages."
+
+specialFiles :: Set FilePath
+specialFiles = S.fromList [
+    ".locks"
+  ]
+
+removePackage :: FilePath -> IO ()
+removePackage fp =
+  -- TODO need to clean up the locks here
+  removeDirectoryRecursive fp
+
+foldSet :: Monad m => Consumer (a, FilePath) m (Set FilePath)
+foldSet =
+  CL.fold (flip (S.insert . snd)) mempty
+
+findLinkedPackages ::
+     (MonadIO m, MonadResource m)
+  => FilePath -> FilePath -> Producer m (F.FileEntry, FilePath)
+findLinkedPackages cache dir =
+  F.sourceFindFiles findOpts dir $ do
+    F.glob "*.conf"
+    conf <- isInCache cache
+    pure (takeDirectory conf)
+
+findLinkedBinaries ::
+     (MonadIO m, MonadResource m)
+  => FilePath -> FilePath -> Producer m (F.FileEntry, FilePath)
+findLinkedBinaries cache bin =
+  F.sourceFindFiles findOpts bin $ do
+    d <- F.getDepth
+    guard (d == 1)
+    isInCache cache
+
+findAllPackages ::
+     (MonadIO m, MonadResource m)
+  => FilePath -> Producer m FilePath
+findAllPackages cache =
+  F.findFilePaths findOpts cache $ do
+    d <- F.getDepth
+    guard (d == 3)
+    F.norecurse
+
+isInCache :: MonadIO m => FilePath -> F.CondT F.FileEntry m FilePath
+isInCache cache = do
+  F.hasStatus U.isSymbolicLink
+  n <- F.getFilePath
+  p <- liftIO (U.readSymbolicLink n)
+  guard (isPrefixOf cache p)
+  F.norecurse
+  pure p
+
+findOpts :: F.FindOptions
+findOpts =
+  F.defaultFindOptions
+  {F.findFollowSymlinks = False, F.findContentsFirst = False}


### PR DESCRIPTION
Really simple/stupid garbage collector POC for the mafia cache. Point it at your root directory (in my case `~/src` contains all my projects, I assume most people have something similar). it'll find any live symlinks to cached packages, record them as Used, and optionally print/delete all the unused packages in the cache. Lets you clean up your disk without interrupting your work (although, true, I stopped work for two hours to write this)

Usage: `mafia-gc ~/.ambiata/mafia ~/src`

Please ignore the PR structure. I have no intent to merge this in the current state, just wanted to share and get some feedback before I spend any time integrating it with mafia.

@olorin @nhibberd does this work on your box? (drop into ghci if you want it to delete stuff, I haven't written any optparse; xargs is fine too)

@jystic would this functionality be worth including in mafia, or is it too hacky / has too many dependencies?

It could easily be a shell script, but there are a lot of different versions of `find` out there, also I've not used `comm` before.