### PR TITLE
Support for running Haskell "shell scripts"

### DIFF
--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -70,15 +70,15 @@ library
                     Mafia.Hash
                     Mafia.Home
                     Mafia.Hoogle
+                    Mafia.IO
                     Mafia.Init
                     Mafia.Install
-                    Mafia.IO
                     Mafia.Lock
                     Mafia.Package
                     Mafia.Path
                     Mafia.Process
                     Mafia.Project
-                    Mafia.Shell
+                    Mafia.Script
                     Mafia.Submodule
                     Mafia.Tree
                     Paths_ambiata_mafia

--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -78,6 +78,7 @@ library
                     Mafia.Path
                     Mafia.Process
                     Mafia.Project
+                    Mafia.Shell
                     Mafia.Submodule
                     Mafia.Tree
                     Paths_ambiata_mafia

--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -30,21 +30,22 @@ import           Mafia.Package
 import           Mafia.Path
 import           Mafia.Process
 import           Mafia.Project
+import           Mafia.Shell
 import           Mafia.Submodule
 import           Mafia.Tree
 
 import           P hiding (Last)
 
-import           System.Exit (exitSuccess)
+import           System.Environment (getArgs)
 import           System.IO (BufferMode(..), hSetBuffering)
-import           System.IO (IO, stdout, stderr, putStrLn, print)
+import           System.IO (IO, stdout, stderr)
 
 import           X.Control.Monad.Trans.Either (EitherT, hoistEither, left)
 import           X.Control.Monad.Trans.Either.Exit (orDie)
 import           X.Options.Applicative (Parser, CommandFields, Mod)
-import           X.Options.Applicative (SafeCommand(..), RunType(..))
-import           X.Options.Applicative (argument, textRead, metavar, help, long, short, option, flag, flag', eitherTextReader)
-import           X.Options.Applicative (dispatch, subparser, safeCommand, command')
+import           X.Options.Applicative (argument, textRead, metavar, help, long, short)
+import           X.Options.Applicative (option, flag, flag', eitherTextReader)
+import           X.Options.Applicative (cli, subparser, command')
 
 ------------------------------------------------------------------------
 
@@ -54,15 +55,17 @@ main = do
   setNumCapabilities nprocs
   hSetBuffering stdout LineBuffering
   hSetBuffering stderr LineBuffering
-  dispatch parser >>= \case
-    VersionCommand ->
-      putStrLn buildInfoVersion >> exitSuccess
-    DependencyCommand ->
-      traverse putStrLn dependencyInfo >> exitSuccess
-    RunCommand DryRun c ->
-      print c >> exitSuccess
-    RunCommand RealRun c ->
-      orDie renderMafiaError (run c)
+  args0 <- getArgs
+  case args0 of
+    "shell" : path : args ->
+      -- bypass optparse until https://github.com/pcapriotti/optparse-applicative/pull/234 is merged
+      runOrDie $ MafiaShell (T.pack path) (fmap T.pack args)
+    _ ->
+      cli "mafia" buildInfoVersion dependencyInfo parser runOrDie
+
+runOrDie :: MafiaCommand -> IO ()
+runOrDie =
+  orDie renderMafiaError . run
 
 ------------------------------------------------------------------------
 
@@ -82,6 +85,7 @@ data MafiaCommand =
   | MafiaWatch [Flag] [GhciInclude] File [Argument]
   | MafiaHoogle [Argument]
   | MafiaInstall [Constraint] InstallPackage
+  | MafiaShell Path [Argument]
     deriving (Eq, Show)
 
 data Warnings =
@@ -134,11 +138,13 @@ run = \case
     mafiaWatch flags incs entry args
   MafiaHoogle args -> do
     mafiaHoogle args
-  MafiaInstall constraints ipkg -> do
+  MafiaInstall constraints ipkg ->
     mafiaInstall ipkg constraints
+  MafiaShell path args ->
+    mafiaShell path args
 
-parser :: Parser (SafeCommand MafiaCommand)
-parser = safeCommand . subparser . mconcat $ commands
+parser :: Parser MafiaCommand
+parser = subparser . mconcat $ commands
 
 commands :: [Mod CommandFields MafiaCommand]
 commands =
@@ -196,6 +202,9 @@ commands =
  , command' "install" ( "Install a hackage package and print the path to its bin directory. "
                      <> "The general usage is as follows:  $(mafia install pretty-show)/ppsh" )
             (MafiaInstall <$> many pConstraint <*> pInstallPackage)
+
+ , command' "shell" "Run a haskell file as a shell script."
+            (MafiaShell <$> pScriptPath <*> many pScriptArgs)
  ]
 
 pProfiling :: Parser Profiling
@@ -292,6 +301,18 @@ pConstraint =
  option (eitherTextReader renderCabalError parseConstraint) $
        long "constraint"
     <> help "Specify constraints on a package (version, installed/source, flags)"
+
+pScriptPath :: Parser File
+pScriptPath =
+  argument textRead $
+       metavar "SCRIPT"
+    <> help "The path to the Haskell shell script."
+
+pScriptArgs :: Parser File
+pScriptArgs =
+  argument textRead $
+       metavar "SCRIPT_ARGUMENTS"
+    <> help "Argument to pass to the shell script."
 
 ------------------------------------------------------------------------
 
@@ -432,6 +453,10 @@ mafiaHoogle args = do
 mafiaInstall :: InstallPackage -> [Constraint] -> EitherT MafiaError IO ()
 mafiaInstall ipkg constraints = do
   liftIO . T.putStrLn =<< firstT MafiaBinError (installBinary ipkg constraints)
+
+mafiaShell :: File -> [Argument] -> EitherT MafiaError IO ()
+mafiaShell file args =
+  firstT MafiaShellError $ runShell file args
 
 ghciArgs :: [GhciInclude] -> [File] -> EitherT MafiaError IO [Argument]
 ghciArgs extraIncludes paths = do

--- a/src/Mafia/Error.hs
+++ b/src/Mafia/Error.hs
@@ -16,6 +16,7 @@ import           Mafia.Install
 import           Mafia.Lock
 import           Mafia.Process
 import           Mafia.Project
+import           Mafia.Shell
 import           Mafia.Submodule
 
 import           P
@@ -36,6 +37,7 @@ data MafiaError
   | MafiaHashError HashError
   | MafiaInitError InitError
   | MafiaLockError LockError
+  | MafiaShellError ShellError
   | MafiaNoInstallConstraints
   | MafiaParseError Text
   | MafiaEntryPointNotFound File
@@ -73,6 +75,9 @@ renderMafiaError = \case
 
   MafiaLockError e ->
     renderLockError e
+
+  MafiaShellError e ->
+    renderShellError e
 
   MafiaNoInstallConstraints ->
     "Could not find the dependency constraints calculated during the last install."

--- a/src/Mafia/Error.hs
+++ b/src/Mafia/Error.hs
@@ -16,7 +16,7 @@ import           Mafia.Install
 import           Mafia.Lock
 import           Mafia.Process
 import           Mafia.Project
-import           Mafia.Shell
+import           Mafia.Script
 import           Mafia.Submodule
 
 import           P
@@ -37,7 +37,7 @@ data MafiaError
   | MafiaHashError HashError
   | MafiaInitError InitError
   | MafiaLockError LockError
-  | MafiaShellError ShellError
+  | MafiaScriptError ScriptError
   | MafiaNoInstallConstraints
   | MafiaParseError Text
   | MafiaEntryPointNotFound File
@@ -76,8 +76,8 @@ renderMafiaError = \case
   MafiaLockError e ->
     renderLockError e
 
-  MafiaShellError e ->
-    renderShellError e
+  MafiaScriptError e ->
+    renderScriptError e
 
   MafiaNoInstallConstraints ->
     "Could not find the dependency constraints calculated during the last install."

--- a/src/Mafia/IO.hs
+++ b/src/Mafia/IO.hs
@@ -35,6 +35,7 @@ module Mafia.IO
   , renameFile
 
     -- * Environment
+  , getExecutablePath
   , findExecutable
   , prependPath
   , lookupEnv
@@ -203,6 +204,10 @@ renameFile src dst = liftIO (Directory.renameFile (T.unpack src) (T.unpack dst))
 
 ------------------------------------------------------------------------
 -- Environment
+
+getExecutablePath :: MonadIO m => m File
+getExecutablePath =
+  liftIO . fmap T.pack $ Environment.getExecutablePath
 
 findExecutable :: MonadIO m => Text -> m (Maybe File)
 findExecutable name = liftIO $ do

--- a/test/cli/shell/expected
+++ b/test/cli/shell/expected
@@ -1,0 +1,7 @@
+[ Int 123
+, String "abc"
+, Int 456
+, String "def"
+, Int 789
+, String "ghi"
+]

--- a/test/cli/shell/run
+++ b/test/cli/shell/run
@@ -1,0 +1,70 @@
+#!/bin/sh -eux
+
+absolute_path() {
+  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
+ROOT=$( cd $(dirname "$0") && pwd -L )
+EXPECTED=$ROOT/expected
+
+MAFIA=$(absolute_path ${1:-./dist/build/mafia/mafia})
+
+MAFIA_TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'mafia')
+SCRIPT=$MAFIA_TEMP/script.hs
+trap "rm -rf \"$MAFIA_TEMP\"" EXIT
+
+cat << EOF > $SCRIPT
+#!$MAFIA shell
+
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+{-# SUBMODULE ambiata/p@3ea83a82b058ba2e1dd216d9e7832fd49cf33dbd #-}
+
+{-# PACKAGE ambiata-p #-}
+{-# PACKAGE pretty-show == 1.6.* #-}
+{-# PACKAGE text == 1.2.* #-}
+
+import qualified Data.Text as T
+import qualified Data.Text.Read as T
+
+import           P
+
+import           System.IO (IO, putStrLn)
+import           System.Environment (getArgs)
+
+import           Text.Show.Pretty (ppShow)
+
+data Argument =
+    Int !Int64
+  | String !Text
+    deriving (Show)
+
+parseArgument :: Text -> Argument
+parseArgument xs =
+  case T.decimal xs of
+    Left _ ->
+      String xs
+    Right (x, "") ->
+      Int x
+    Right _ ->
+      String xs
+
+main :: IO ()
+main = do
+  args <- fmap (parseArgument . T.pack) <$> getArgs
+  putStrLn $ ppShow args
+EOF
+
+chmod +x $SCRIPT
+
+if hash colordiff 2>/dev/null; then
+  DIFF=colordiff
+else
+  DIFF=diff
+fi
+
+cd $MAFIA_TEMP
+# First run contains build output, so write to /dev/null
+MAFIA_HOME=$MAFIA_TEMP $SCRIPT 123 abc 456 def 789 ghi >/dev/null
+MAFIA_HOME=$MAFIA_TEMP $SCRIPT 123 abc 456 def 789 ghi | $DIFF -u $EXPECTED -

--- a/test/cli/shell/run
+++ b/test/cli/shell/run
@@ -14,7 +14,7 @@ SCRIPT=$MAFIA_TEMP/script.hs
 trap "rm -rf \"$MAFIA_TEMP\"" EXIT
 
 cat << EOF > $SCRIPT
-#!$MAFIA shell
+#!$MAFIA script
 
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}


### PR DESCRIPTION
This adds a new command `mafia script` which allows the use of mafia as a shebang interpreter, for example:

```hs
#!/usr/bin/env mafia script

{-# LANGUAGE NoImplicitPrelude #-}
{-# LANGUAGE OverloadedStrings #-}

{-# SUBMODULE ambiata/p@3ea83a82b058ba2e1dd216d9e7832fd49cf33dbd #-}

{-# PACKAGE ambiata-p #-}
{-# PACKAGE pretty-show #-}
{-# PACKAGE text #-}

import qualified Data.Text as T
import qualified Data.Text.Read as T

import           P

import           System.IO (IO, putStrLn)
import           System.Environment (getArgs)

import           Text.Show.Pretty (ppShow)

data Argument =
    Int !Int64
  | String !Text
    deriving (Show)

parseArgument :: Text -> Argument
parseArgument xs =
  case T.decimal xs of
    Left _ ->
      String xs
    Right (x, "") ->
      Int x
    Right _ ->
      String xs

main :: IO ()
main = do
  args <- fmap (parseArgument . T.pack) <$> getArgs
  putStrLn $ ppShow args
```

~~I'm not sure if `mafia shell` is the best name, as it's not really a shell, suggestions welcome.~~

I think this will be useful for sharing code snippets, and trying things out without having to start up a whole new project.

! @nhibberd @charleso @thumphries 