### PR TITLE
Include cabal_macros.h when launching 'mafia quick'

### DIFF
--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -504,7 +504,7 @@ ghciArgs extraIncludes paths = do
 
   let
     dirs =
-      ["src", "test", "gen", "dist/build/autogen"] <> extras
+      ["src", "test", "gen", "dist/build", "dist/build/autogen"] <> extras
 
   headers <- getHeaders
   includes <- catMaybes <$> mapM ensureDirectory dirs
@@ -548,7 +548,7 @@ reifyInclude = \case
     absDirs <- Set.toList <$> firstT MafiaSubmoduleError getSubmoduleSources
     relDirs <- mapM tryMakeRelativeToCurrent absDirs
     return [ dir </> sub | dir <- relDirs
-                         , sub <- ["src", "test", "gen", "dist/build/autogen"] ]
+                         , sub <- ["src", "test", "gen", "dist/build", "dist/build/autogen"] ]
 
 ensureDirectory :: MonadIO m => Directory -> m (Maybe Directory)
 ensureDirectory dir = do

--- a/src/Mafia/Cabal/Sandbox.hs
+++ b/src/Mafia/Cabal/Sandbox.hs
@@ -92,9 +92,9 @@ sandboxRoot =
 -- | The location where the sandbox is inferred to be (based on the GHC version)
 getInferredSandboxDir :: EitherT CabalError IO SandboxDir
 getInferredSandboxDir = do
-  GhcTarget target <- firstT CabalGhcError getGhcTarget
-  GhcVersion version <- firstT CabalGhcError getGhcVersion
-  return $ sandboxRoot </> target </> version
+  target <- firstT CabalGhcError getGhcTarget
+  version <- firstT CabalGhcError getGhcVersion
+  return $ sandboxRoot </> unGhcTarget target </> renderGhcVersion version
 
 -- | The location where the sandbox is configured to be (based on the cabal.sandbox.config)
 getSandboxDir :: EitherT CabalError IO SandboxDir

--- a/src/Mafia/Error.hs
+++ b/src/Mafia/Error.hs
@@ -9,6 +9,7 @@ module Mafia.Error
 
 import           Mafia.Bin
 import           Mafia.Cabal.Types
+import           Mafia.Ghc
 import           Mafia.Git
 import           Mafia.Hash
 import           Mafia.Init
@@ -30,6 +31,7 @@ data MafiaError
   = MafiaProjectError ProjectError
   | MafiaProcessError ProcessError
   | MafiaGitError GitError
+  | MafiaGhcError GhcError
   | MafiaCabalError CabalError
   | MafiaSubmoduleError SubmoduleError
   | MafiaInstallError InstallError
@@ -54,6 +56,9 @@ renderMafiaError = \case
 
   MafiaGitError e ->
     renderGitError e
+
+  MafiaGhcError e ->
+    renderGhcError e
 
   MafiaCabalError e ->
     renderCabalError e

--- a/src/Mafia/Install.hs
+++ b/src/Mafia/Install.hs
@@ -480,7 +480,7 @@ envPackageCache env =
     </> "packages"
     </> T.pack (show envPackageCacheVersion)
     </> unGhcTarget (envGhcTarget env)
-    </> unGhcVersion (envGhcVersion env)
+    </> renderGhcVersion (envGhcVersion env)
 
 getPackageEnv :: EitherT InstallError IO PackageEnv
 getPackageEnv = do

--- a/src/Mafia/Lock.hs
+++ b/src/Mafia/Lock.hs
@@ -48,9 +48,9 @@ renderLockError = \case
 
 getLockFile :: Directory -> EitherT LockError IO File
 getLockFile dir = do
-  GhcVersion ghcver <- firstT LockGhcError getGhcVersion
+  version <- firstT LockGhcError getGhcVersion
   project <- firstT LockProjectError $ getProjectName dir
-  return $ dir </> project <> ".lock-" <> ghcver
+  return $ dir </> project <> ".lock-" <> renderGhcVersion version
 
 lockFileHeader :: Text
 lockFileHeader =


### PR DESCRIPTION
This allows usages of `CPP` which rely on version macros in GHC 7.10 and earlier, when loading a file with `quick`.

GHC 8.0 already does something similar by itself.

Fixes https://github.com/ambiata/mafia/issues/35

! @nhibberd @charleso 