### PR TITLE
test: Use HTTPS instead of GIT protocol

### DIFF
--- a/test/cli/basic-usage/run
+++ b/test/cli/basic-usage/run
@@ -22,7 +22,7 @@ check() {
 
   cd ${MAFIA_TEMP}
   if [ ! -d "${MAFIA_REPO}" ]; then
-    git clone git@github.com:ambiata/${MAFIA_REPO}
+    git clone https://github.com/ambiata/${MAFIA_REPO}
   fi
 
   cd ${MAFIA_DIR}

--- a/test/cli/hoogle/run
+++ b/test/cli/hoogle/run
@@ -10,7 +10,7 @@ MAFIA_TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'mafia')
 trap "rm -rf \"${MAFIA_TEMP}\"" EXIT
 
 cd ${MAFIA_TEMP}
-git clone git@github.com:ambiata/p.git
+git clone https://github.com/ambiata/p.git
 cd p
 
 MAFIA_HOME=${MAFIA_TEMP} ${MAFIA} hoogle "fst" | grep -F "Prelude fst :: (a, b) -> a"


### PR DESCRIPTION
Mainly so that people outside Ambiata can build/run the tests.

! @jystic