### PR TITLE
Add -p (--project) flag to mafia ghci/quick/watch

### DIFF
--- a/src/Mafia/Init.hs
+++ b/src/Mafia/Init.hs
@@ -325,7 +325,7 @@ getCabalFileHash dir = do
 
 getSourceDependencies :: EitherT InitError IO (Set SourcePackage)
 getSourceDependencies = do
-  sources <- Set.toList <$> firstT InitSubmoduleError getSubmoduleSources
+  sources <- Set.toList <$> firstT InitSubmoduleError getAvailableSources
   Set.fromList . catMaybes <$> firstT InitCabalError (mapConcurrentlyE getSourcePackage sources)
 
 readMafiaState :: File -> EitherT InitError IO (Maybe MafiaState)


### PR DESCRIPTION
This flag automatically adds all of the current project's (i.e. git repository) source directories to the ghci include path.

So if I'm in project `foo`, in the `foo-cli` directory:
```
foo-data
└─ src
   └─ Foo
      └─ Data.hs
foo-cli
├─ main
│  └─ foo.hs
└─ src
   └─ Foo
      └─ Commands.hs
```
and I run:
```
~/src/foo/foo-cli $ mafia ghci -p main/foo.hs
```
Then not only will I get `foo-cli/src` loaded in the interpreter, I will also get `foo-data/src` loaded in the interpreter.

This is similar to the `-a` / `--all` flag which already exists, but that loads all of submodules in the interpreter as well, which is often overkill and sometimes doesn't work for various reasons.

! @charleso @erikd-ambiata @thumphries @nhibberd 