### PR TITLE
Parse include dirs to return cflags

### DIFF
--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -75,6 +75,7 @@ library
                     Mafia.Init
                     Mafia.Install
                     Mafia.Lock
+                    Mafia.Makefile
                     Mafia.Package
                     Mafia.Path
                     Mafia.Process

--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -71,6 +71,7 @@ library
                     Mafia.Home
                     Mafia.Hoogle
                     Mafia.IO
+                    Mafia.Include
                     Mafia.Init
                     Mafia.Install
                     Mafia.Lock

--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -642,7 +642,8 @@ initMafia prof flags = do
 
   firstT MafiaInitError $ initialize (Just prof) (Just flags)
 
-  buildMakefile
+  directory <- firstT MafiaCabalError $ getCurrentDirectory
+  buildMakefile directory
 
 ensureBuildTools :: EitherT MafiaError IO ()
 ensureBuildTools = do

--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -656,12 +656,13 @@ ensureBuildTools = do
 callMakefile :: File -> EitherT MafiaError IO ()
 callMakefile makeFile = do
   mafia <- getExecutablePath
+  env   <- getEnvironment
   Pass  <- firstT MafiaProcessError
          $ callProcess
          $ Process
          { processCommand     = "make"
          , processArguments   = ["-f", makeFile]
          , processDirectory   = Nothing
-         , processEnvironment = Just (Map.singleton "MAFIA" mafia) }
+         , processEnvironment = Just (Map.insert "MAFIA" mafia env) }
   return ()
 

--- a/src/Mafia/Cabal/Process.hs
+++ b/src/Mafia/Cabal/Process.hs
@@ -17,7 +17,6 @@ import           Mafia.Process
 
 import           P
 
-import           System.Environment (getEnvironment)
 import           System.IO (IO)
 
 import           X.Control.Monad.Trans.Either (EitherT)
@@ -54,7 +53,7 @@ cabalFrom dir sbcfg extraPath cmd args = do
 
 mkEnv :: SandboxConfigFile -> [Directory] -> IO (Map EnvKey EnvValue)
 mkEnv sbcfg extraPaths =
-  fmap (Map.insert "CABAL_SANDBOX_CONFIG" sbcfg . prependPaths extraPaths) getEnv
+  fmap (Map.insert "CABAL_SANDBOX_CONFIG" sbcfg . prependPaths extraPaths) getEnvironment
 
 prependPaths :: [Directory] -> Map EnvKey EnvValue -> Map EnvKey EnvValue
 prependPaths new kvs =
@@ -67,7 +66,3 @@ prependPaths new kvs =
         Map.insert key (T.intercalate ":" new) kvs
       Just old ->
         Map.insert key (T.intercalate ":" $ new <> T.splitOn ":" old) kvs
-
-getEnv :: IO (Map EnvKey EnvValue)
-getEnv =
-  Map.fromList . fmap (bimap T.pack T.pack) <$> getEnvironment

--- a/src/Mafia/Cabal/Process.hs
+++ b/src/Mafia/Cabal/Process.hs
@@ -14,6 +14,7 @@ import qualified Data.Text as T
 
 import           Mafia.Cabal.Types
 import           Mafia.Process
+import           Mafia.IO (getEnvironment)
 
 import           P
 

--- a/src/Mafia/IO.hs
+++ b/src/Mafia/IO.hs
@@ -234,7 +234,7 @@ unsetEnv :: MonadIO m => Text -> m ()
 unsetEnv key = liftIO $
   Environment.unsetEnv (T.unpack key)
 
-getEnvironment :: MonadIO m => m (Map Text Text)
+getEnvironment :: (Functor m, MonadIO m) => m (Map Text Text)
 getEnvironment =
   Map.fromList . fmap (bimap T.pack T.pack) <$> liftIO Environment.getEnvironment
 

--- a/src/Mafia/IO.hs
+++ b/src/Mafia/IO.hs
@@ -41,6 +41,7 @@ module Mafia.IO
   , lookupEnv
   , setEnv
   , unsetEnv
+  , getEnvironment
 
     -- * Pre-defined directories
   , getHomeDirectory
@@ -63,6 +64,8 @@ import           Control.Monad.Trans.Maybe (MaybeT(..))
 
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as B
+import           Data.Map (Map)
+import qualified Data.Map as Map
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import           Data.Time (UTCTime)
@@ -230,6 +233,11 @@ setEnv key value = liftIO $
 unsetEnv :: MonadIO m => Text -> m ()
 unsetEnv key = liftIO $
   Environment.unsetEnv (T.unpack key)
+
+getEnvironment :: MonadIO m => m (Map Text Text)
+getEnvironment =
+  Map.fromList . fmap (bimap T.pack T.pack) <$> liftIO Environment.getEnvironment
+
 
 ------------------------------------------------------------------------
 -- Pre-defined directories

--- a/src/Mafia/Include.hs
+++ b/src/Mafia/Include.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternGuards #-}
+module Mafia.Include
+  ( getIncludeDirs
+  ) where
+
+import qualified Data.Text as T
+
+import           Mafia.Cabal
+import           Mafia.IO
+import           Mafia.Path
+import           Mafia.Error
+
+import           P
+
+import           System.IO (IO)
+
+import           X.Control.Monad.Trans.Either (EitherT)
+
+getIncludeDirs :: EitherT MafiaError IO [Path]
+getIncludeDirs = do
+  packageDB     <- firstT MafiaCabalError getPackageDB
+  subdirs       <- getDirectoryListing (RecursiveDepth 0) packageDB
+  let packages = filter (extension ".conf") subdirs
+  concat <$> mapM readIncludeDirs packages
+
+readIncludeDirs :: File -> EitherT MafiaError IO [Path]
+readIncludeDirs package = do
+  contents <- readUtf8 package
+  return $
+    case contents of
+     Nothing -> []
+     Just txt -> concatMap parseLine $ T.lines txt
+
+parseLine :: Text -> [Path]
+parseLine line
+ | (i:is) <- T.words line
+ , T.toLower i == "include-dirs:"
+ = is
+ | otherwise
+ = []
+

--- a/src/Mafia/Makefile.hs
+++ b/src/Mafia/Makefile.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Mafia.Makefile
+  ( buildMakefile
+  ) where
+
+import qualified Data.Map as Map
+
+import           Mafia.Cabal
+import           Mafia.IO
+import           Mafia.Path
+import           Mafia.Process
+import           Mafia.Error
+
+import           P
+
+import           System.IO (IO)
+
+import           X.Control.Monad.Trans.Either (EitherT)
+
+buildMakefile :: EitherT MafiaError IO ()
+buildMakefile = do
+  cabalFile <- firstT MafiaCabalError $ getCabalFile =<< getCurrentDirectory
+  let makeFile = dropExtension cabalFile <> ".mk"
+  whenM (doesFileExist makeFile) $ do
+    callMakefile makeFile
+
+callMakefile :: File -> EitherT MafiaError IO ()
+callMakefile makeFile = do
+  mafia <- getExecutablePath
+  env   <- getEnvironment
+  Pass  <- firstT MafiaProcessError
+         $ callProcess
+         $ Process
+         { processCommand     = "make"
+         , processArguments   = ["-f", makeFile]
+         , processDirectory   = Nothing
+         , processEnvironment = Just (Map.insert "MAFIA" mafia env) }
+  return ()
+

--- a/src/Mafia/Makefile.hs
+++ b/src/Mafia/Makefile.hs
@@ -18,7 +18,7 @@ import           System.IO (IO)
 
 import           X.Control.Monad.Trans.Either (EitherT)
 
-buildMakefile :: Path -> EitherT MafiaError IO ()
+buildMakefile :: Directory -> EitherT MafiaError IO ()
 buildMakefile directory = do
   cabalFile <- firstT MafiaCabalError $ getCabalFile directory
   let makeFile = dropExtension cabalFile <> ".mk"

--- a/src/Mafia/Makefile.hs
+++ b/src/Mafia/Makefile.hs
@@ -18,9 +18,9 @@ import           System.IO (IO)
 
 import           X.Control.Monad.Trans.Either (EitherT)
 
-buildMakefile :: EitherT MafiaError IO ()
-buildMakefile = do
-  cabalFile <- firstT MafiaCabalError $ getCabalFile =<< getCurrentDirectory
+buildMakefile :: Path -> EitherT MafiaError IO ()
+buildMakefile directory = do
+  cabalFile <- firstT MafiaCabalError $ getCabalFile directory
   let makeFile = dropExtension cabalFile <> ".mk"
   whenM (doesFileExist makeFile) $ do
     callMakefile makeFile

--- a/src/Mafia/Process.hs
+++ b/src/Mafia/Process.hs
@@ -13,7 +13,6 @@ module Mafia.Process
   , EnvKey
   , EnvValue
   , Process(..)
-  , getEnvironment
 
     -- * Outputs
   , Pass(..)
@@ -64,7 +63,6 @@ import           Mafia.IO (setCurrentDirectory)
 
 import           P
 
-import qualified System.Environment as Env
 import           System.Exit (ExitCode(..))
 import           System.IO (IO, FilePath, Handle, BufferMode(..))
 import qualified System.IO as IO
@@ -86,10 +84,6 @@ data Process = Process
   , processDirectory   :: Maybe Directory
   , processEnvironment :: Maybe (Map EnvKey EnvValue)
   } deriving (Eq, Ord, Show)
-
-getEnvironment :: MonadIO m => m (Map EnvKey EnvValue)
-getEnvironment =
-  Map.fromList . fmap (bimap T.pack T.pack) <$> liftIO Env.getEnvironment
 
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Process.hs
+++ b/src/Mafia/Process.hs
@@ -13,6 +13,7 @@ module Mafia.Process
   , EnvKey
   , EnvValue
   , Process(..)
+  , getEnvironment
 
     -- * Outputs
   , Pass(..)
@@ -63,6 +64,7 @@ import           Mafia.IO (setCurrentDirectory)
 
 import           P
 
+import qualified System.Environment as Env
 import           System.Exit (ExitCode(..))
 import           System.IO (IO, FilePath, Handle, BufferMode(..))
 import qualified System.IO as IO
@@ -84,6 +86,10 @@ data Process = Process
   , processDirectory   :: Maybe Directory
   , processEnvironment :: Maybe (Map EnvKey EnvValue)
   } deriving (Eq, Ord, Show)
+
+getEnvironment :: MonadIO m => m (Map EnvKey EnvValue)
+getEnvironment =
+  Map.fromList . fmap (bimap T.pack T.pack) <$> liftIO Env.getEnvironment
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
Print out the include things you need to pass to your C compiler.
You can use this to compile your C files

```
$ mafia cflags
 -I/Users/amos/.mafia/packages/2/x86_64-apple-darwin/7.10.2/ambiata-anemone-0.0.1-4c157d411db877692c02d0297507ffd9bb516d01/lib/x86_64-osx-ghc-7.10.2/ambiata-anemone-0.0.1-BOjrLw9wQaXALtoAVtoD7u/include -I/Users/amos/.mafia/packages/2/x86_64-apple-darwin/7.10.2/bindings-DSL-1.0.23-7459d4f266876e2b4a0cc2e55bd4670585a5e5de/lib/x86_64-osx-ghc-7.10.2/bindings-DSL-1.0.23-CYYoENzCWsxLIHUutFUcwg/include -I/Users/amos/.mafia/packages/2/x86_64-apple-darwin/7.10.2/old-time-1.1.0.3-c276895bd9042f9c6651efca0aaf90498d93d7f0/lib/x86_64-osx-ghc-7.10.2/old-time-1.1.0.3-6a6Jx6d2eoV1WrlI7mHX3Y/include -I/Users/amos/.mafia/packages/2/x86_64-apple-darwin/7.10.2/primitive-0.6.1.0-704d9600eaa6857a9716fb5d15747f242f472f33/lib/x86_64-osx-ghc-7.10.2/primitive-0.6.1.0-B6ODYLTZGY3Lrs4xU9YB7s/include -I/Users/amos/.mafia/packages/2/x86_64-apple-darwin/7.10.2/vector-0.11.0.0-63cd2459b42de57e59f34cd894171549bdfe21ee/lib/x86_64-osx-ghc-7.10.2/vector-0.11.0.0-IAfgjY7a1dEhXgUYYRB2g/include


$ gcc csrc/some_file.h
csrc/some_file.h:4:10: fatal error: 'anemone_base.h' file not found
#include "anemone_base.h"
         ^
1 error generated.

$ gcc csrc/some_file.h `mafia cflags`
(ok)
```

! @jystic @tranma 
/jury approved @jystic @tranma