### PR TITLE
Support for running quick/ghci/watch from anywhere

### DIFF
--- a/src/Mafia/Path.hs
+++ b/src/Mafia/Path.hs
@@ -13,6 +13,7 @@ module Mafia.Path
   , dropTrailingPathSeparator
   , normalise
   , makeRelative
+  , isAbsolute
 
     -- * Extension functions
   , takeExtension
@@ -51,6 +52,9 @@ dropTrailingPathSeparator = T.pack . FilePath.dropTrailingPathSeparator . T.unpa
 
 normalise :: Path -> Path
 normalise = T.pack . FilePath.normalise . T.unpack
+
+isAbsolute :: Path -> Bool
+isAbsolute = FilePath.isAbsolute . T.unpack
 
 makeRelative :: Path -> Path -> Maybe Path
 makeRelative xp yp =


### PR DESCRIPTION
This change makes it possible to run `mafia quick` (and friends) from inside any working directory and have it automatically use the right sandbox.

e.g.
```
$ ls
icicle-compiler     icicle-core     icicle-data     icicle-repl     icicle-source
$ mafia quick icicle-compiler/src/Icicle/Compiler.hs
*Icicle.Compiler
λ
```

Note that the `icicle-compiler` sandbox was automatically selected without having to change to that directory.

This is particular useful when combined with an editor which can involve the repl on the currently active buffer.

! @nhibberd @charleso @thumphries 
/jury approved @tranma @nhibberd