### PR TITLE
Replace other-modules with exposed-modules for Hackage packages

### DIFF
--- a/src/Mafia/Install.hs
+++ b/src/Mafia/Install.hs
@@ -365,6 +365,9 @@ createPackageSandbox penv p@(Package (PackageRef pid _ msrc) deps _) = do
       capture (InstallUnpackFailed pid sbsrc) $
         sbcabal "unpack" ["--destdir=" <> sbsrc, renderPackageId pid]
 
+      -- Presumably we don't need to do this for local packages ever.
+      exposePackageModules srcdir
+
       Hush <- sbcabal "sandbox" ["add-source", srcdir]
 
       -- We need to shuffle anything which was unpacked to 'dist' in to
@@ -401,6 +404,44 @@ createPackageSandbox penv p@(Package (PackageRef pid _ msrc) deps _) = do
   Hush <- sbcabal "sandbox" ["hc-pkg", "recache"]
 
   return ty
+
+exposePackageModules :: Directory -> EitherT InstallError IO ()
+exposePackageModules dir = do
+  cabalFile <- firstT InstallCabalError $ getCabalFile dir
+  contents  <- readUtf8 cabalFile
+  case contents of
+    Nothing ->
+      return ()
+    Just str -> do
+      let
+        -- sections that can have other-modules but not exposed-modules
+        sections =
+          [ "executable"
+          , "test-suite"
+          , "benchmark" ]
+
+        isLibrary s =
+          let
+            (_, x) = T.breakOnEnd "library" s
+          in not (T.null x) && not (any (flip T.isInfixOf x) sections)
+
+        replace [x]
+          = [x]
+        replace []
+          = []
+        replace (x:xs)
+          | isLibrary x
+          = [x, "exposed-modules"] <> replace xs
+          | otherwise
+          = [x, "other-modules"] <> replace xs
+
+        ss =
+          T.splitOn "other-modules" str
+
+        str' =
+          T.concat (replace ss)
+
+      writeUtf8 cabalFile str'
 
 -- | Install the specified build tools and return the paths to the 'bin' directories.
 installBuildTools :: PackageEnv -> Set BuildTool -> EitherT InstallError IO [Directory]


### PR DESCRIPTION
Replace `other-modules` in the `library` section:

```
$ sdiff old new
library								library
  hs-source-dirs:						  hs-source-dirs:
    src								    src
  ghc-options: -Wall						  ghc-options: -Wall
  build-depends:						  build-depends:
    base >= 4.3 && < 5,						    base >= 4.3 && < 5,
    ghc-prim							    ghc-prim
  exposed-modules:						  exposed-modules:
    Data.Orphans						    Data.Orphans
  other-modules:					      |	  exposed-modules:
    Data.Orphans.Prelude					    Data.Orphans.Prelude
  default-language: Haskell2010					  default-language: Haskell2010

test-suite spec							test-suite spec
  type: exitcode-stdio-1.0					  type: exitcode-stdio-1.0
  main-is: Spec.hs						  main-is: Spec.hs
  hs-source-dirs:						  hs-source-dirs:
    test							    test
  ghc-options: -Wall						  ghc-options: -Wall
  build-depends:						  build-depends:
    base >= 4.3 && < 5,						    base >= 4.3 && < 5,
    base-orphans,						    base-orphans,
    hspec == 2.*,						    hspec == 2.*,
    QuickCheck							    QuickCheck
  other-modules:						  other-modules:
    Control.Applicative.OrphansSpec				    Control.Applicative.OrphansSpec
    Control.Exception.OrphansSpec				    Control.Exception.OrphansSpec
...
```

I'm sorry.

! @jystic 
/jury approved @amosr