### PR TITLE
Add retry to cabal downloads

### DIFF
--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -33,6 +33,7 @@ library
                     , memory                          == 0.12.*
                     , parallel                        == 3.2.*
                     , process                         >= 1.4        && < 1.5
+                    , retry                           == 0.7.*
                     , stm                             == 2.4.*
                     , tar                             == 0.4.*
                     , temporary                       == 1.2.*


### PR DESCRIPTION
This adds retries to the places where we ask cabal to download from hackage, it should fix the errors we've been seeing on CI, like this one:
```
Failed to unpack aeson-0.11.2.0 to /mnt/boris-service/work/mafia-build-tools-32017
Process failed with exit code: 1
Downloading aeson-0.11.2.0...
<socket: 14>: hGetBufSome: resource vanished (Connection reset by peer)
```

! @thumphries @nhibberd 
/jury approved @tmcgilchrist @thumphries