### PR TITLE
Update mafia script to remove version lock.

### DIFF
--- a/script/mafia
+++ b/script/mafia
@@ -25,9 +25,10 @@ build_version() {
         exit "$got"
     }
     chmod +x "$MAFIA_TEMP/.cabal-sandbox/bin/mafia"
-    # Ensure it executable is on same file-system so final mv is atomic.
+    # Ensure executable is on same file-system so final mv is atomic.
     mv -f "$MAFIA_TEMP/.cabal-sandbox/bin/mafia" "$MAFIA_PATH.$$"
     mv "$MAFIA_PATH.$$" "$MAFIA_PATH" || {
+        rm -f "$MAFIA_PATH.$$"
         echo "INFO: mafia version ($MAFIA_VERSION) already exists not overiding," >&2
         echo "INFO: this is expected if parallel builds of the same version of" >&2
         echo "INFO: mafia occur, we are playing by first in, wins." >&2

--- a/script/mafia
+++ b/script/mafia
@@ -37,7 +37,7 @@ build_version() {
 }
 
 enable_version() {
-    if [ $# -eq 0 ]; then
+    if [ $# -ne 0 ]; then
         MAFIA_VERSION="$(latest_version)"
         echo "INFO: No explicit mafia version requested installing latest ($MAFIA_VERSION)." >&2
     else
@@ -57,6 +57,6 @@ exec_mafia () {
 #
 
 case "${1:-}" in
-set-mafia-version) shift; enable_version "$@" ;;
+upgrade) shift; enable_version "$@" ;;
 *) exec_mafia "$@"
 esac

--- a/script/mafia
+++ b/script/mafia
@@ -1,122 +1,61 @@
 #!/bin/sh -eu
 
 : ${MAFIA_HOME:=$HOME/.mafia}
-
-fetch_latest () {
-  if [ -z ${MAFIA_TEST_MODE+x} ]; then
-    TZ=$(date +"%T")
-    curl --silent "https://raw.githubusercontent.com/ambiata/mafia/master/script/mafia?$TZ"
-  else
-    cat ../script/mafia
-  fi
-}
+: ${MAFIA_VERSIONS:=$MAFIA_HOME/versions}
 
 latest_version () {
-  git ls-remote https://github.com/ambiata/mafia | grep refs/heads/master | cut -f 1
+    git ls-remote https://github.com/ambiata/mafia | grep refs/heads/master | cut -f 1
 }
 
-local_version () {
-  awk '/^# Version: / { print $3; exit 0; }' $0
+build_version() {
+    MAFIA_VERSION="$1"
+    MAFIA_TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'exec_mafia')
+    MAFIA_FILE=mafia-$MAFIA_VERSION
+    MAFIA_PATH=$MAFIA_VERSIONS/$MAFIA_FILE
+    mkdir -p $MAFIA_VERSIONS
+    echo "Building $MAFIA_FILE in $MAFIA_TEMP"
+    git clone https://github.com/ambiata/mafia $MAFIA_TEMP
+    git --git-dir="$MAFIA_TEMP/.git" --work-tree="$MAFIA_TEMP" reset --hard $MAFIA_VERSION || {
+        echo "mafia version ($MAFIA_VERSION) could not be found." >&2
+        exit 1
+    }
+    (cd "$MAFIA_TEMP" && ./bin/bootstrap) || {
+        got=$?
+        echo "mafia version ($MAFIA_VERSION) could not be built." >&2
+        exit "$got"
+    }
+    chmod +x "$MAFIA_TEMP/.cabal-sandbox/bin/mafia"
+    # Ensure it executable is on same file-system so final mv is atomic.
+    mv -f "$MAFIA_TEMP/.cabal-sandbox/bin/mafia" "$MAFIA_PATH.$$"
+    mv "$MAFIA_PATH.$$" "$MAFIA_PATH" || {
+        echo "INFO: mafia version ($MAFIA_VERSION) already exists not overiding," >&2
+        echo "INFO: this is expected if parallel builds of the same version of" >&2
+        echo "INFO: mafia occur, we are playing by first in, wins." >&2
+        exit 0
+    }
 }
 
-run_upgrade () {
-  MAFIA_TEMP=$(mktemp 2>/dev/null || mktemp -t 'upgrade_mafia')
-
-  clean_up () {
-    rm -f "$MAFIA_TEMP"
-  }
-
-  trap clean_up EXIT
-
-  MAFIA_CUR="$0"
-
-  if [ -L "$MAFIA_CUR" ]; then
-    echo 'Refusing to overwrite a symlink; run `upgrade` from the canonical path.' >&2
-    exit 1
-  fi
-
-  echo "Checking for a new version of mafia ..."
-  fetch_latest > $MAFIA_TEMP
-
-  LATEST_VERSION=$(latest_version)
-  echo "# Version: $LATEST_VERSION" >> $MAFIA_TEMP
-
-  if ! cmp $MAFIA_CUR $MAFIA_TEMP >/dev/null 2>&1; then
-    mv $MAFIA_TEMP $MAFIA_CUR
-    chmod +x $MAFIA_CUR
-    echo "New version found and upgraded. You can now commit it to your git repo."
-  else
-    echo "You have latest mafia."
-  fi
+enable_version() {
+    if [ $# -eq 0 ]; then
+        MAFIA_VERSION="$(latest_version)"
+        echo "INFO: No explicit mafia version requested installing latest ($MAFIA_VERSION)." >&2
+    else
+        MAFIA_VERSION="$1"
+    fi
+    [ -x "$MAFIA_HOME/versions/mafia-$MAFIA_VERSION" ] || build_version "$MAFIA_VERSION"
+    ln -sf "$MAFIA_HOME/versions/mafia-$MAFIA_VERSION" "$MAFIA_HOME/versions/mafia"
 }
 
 exec_mafia () {
-  MAFIA_VERSION=$(local_version)
-
-  if [ "x$MAFIA_VERSION" = "x" ]; then
-    # If we can't find the mafia version, then we need to upgrade the script.
-    run_upgrade
-  else
-    MAFIA_BIN=$MAFIA_HOME/bin
-    MAFIA_FILE=mafia-$MAFIA_VERSION
-    MAFIA_PATH=$MAFIA_BIN/$MAFIA_FILE
-
-    [ -f "$MAFIA_PATH" ] || {
-      # Create a temporary directory which will be deleted when the script
-      # terminates. Unfortunately `mktemp` doesn't behave the same on
-      # Linux and OS/X so we need to try two different approaches.
-      MAFIA_TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'exec_mafia')
-
-      # Create a temporary file in MAFIA_BIN so we can do an atomic copy/move dance.
-      mkdir -p $MAFIA_BIN
-
-      clean_up () {
-        rm -rf "$MAFIA_TEMP"
-      }
-
-      trap clean_up EXIT
-
-      echo "Building $MAFIA_FILE in $MAFIA_TEMP"
-
-      ( cd "$MAFIA_TEMP"
-
-        git clone https://github.com/ambiata/mafia
-        cd mafia
-
-        git reset --hard $MAFIA_VERSION
-
-        bin/bootstrap ) || exit $?
-
-      MAFIA_PATH_TEMP=$(mktemp --tmpdir=$MAFIA_BIN $MAFIA_FILE-XXXXXX 2>/dev/null || TMPDIR=$MAFIA_BIN mktemp -t $MAFIA_FILE)
-
-      clean_up_temp () {
-        clean_up
-        rm -f "$MAFIA_PATH_TEMP"
-      }
-      trap clean_up_temp EXIT
-
-      cp "$MAFIA_TEMP/mafia/.cabal-sandbox/bin/mafia" "$MAFIA_PATH_TEMP"
-      chmod 755 "$MAFIA_PATH_TEMP"
-      mv "$MAFIA_PATH_TEMP" "$MAFIA_PATH"
-
-      clean_up_temp
-    }
-
-    exec $MAFIA_PATH "$@"
-  fi
+    [ -x "$MAFIA_HOME/versions/mafia" ] || enable_version
+    "$MAFIA_HOME/versions/mafia" "$@"
 }
 
 #
 # The actual start of the script.....
 #
 
-if [ $# -gt 0 ]; then
-  MODE="$1"
-else
-  MODE=""
-fi
-
-case "$MODE" in
-upgrade) shift; run_upgrade "$@" ;;
+case "${1:-}" in
+set-mafia-version) shift; enable_version "$@" ;;
 *) exec_mafia "$@"
 esac


### PR DESCRIPTION
This matches a change in usage that is more
common for mafia now. The original reasoning
for the lock, was so we could control version
breakage of mafia itself if required. At the
time we weren't sure how stable it could /
would be. In retrospect, the mafia API has
been able to remain very stable, and it has
actually (probably unsurprisingly) been the
unrelenting churn on hackage that has caused
the most issues. This led to a prefer the
latest mafia, and it promises to be backwards
compatiable approach. This means that later
versions of mafia can handle hackage breakage
and projects will keep building from checkout.

The script becomes a small version manager for
mafia. From checkout, everything just works
without a previous install of mafia:

  './mafia build'

This will install the latest version of mafia
and build your project. If you already have a
local build of mafia, it will continue to use
this, if you want to use the latest run:

  './mafia set-mafia-version'

This will build and link the latest mafia version.
If you want to run a specific git commit of mafia
you can:

  './mafia set-mafia-version f52d11e0beeedbd8ba31ad8ec3a760a8b670c138'

As it stands it removes the interactive upgrade
command on the local mafia script.

There are a couple of inline comments for somewhat 
arbitrary decisions I have made that are worth further
discussion.