### PR TITLE
Use Cabal API for determining package-id of submodules

### DIFF
--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -541,7 +541,6 @@ mafiaExec args = do
           (x:xs) -> x : "--" : xs
   exec MafiaProcessError "cabal" $ "exec" : fixedArgs
 
-
 mafiaCFlags :: EitherT MafiaError IO ()
 mafiaCFlags = do
   dirs <- getIncludeDirs
@@ -550,7 +549,6 @@ mafiaCFlags = do
   printIncludes dirs = liftIO $ do
     mapM_ (\d -> T.putStr " -I" >> T.putStr d) dirs
     T.putStrLn ""
-
 
 ghciArgs :: [GhciInclude] -> [File] -> EitherT MafiaError IO [Argument]
 ghciArgs extraIncludes paths = do
@@ -651,4 +649,3 @@ ensureBuildTools = do
 
   firstT MafiaBinError . for_ tools $ \(BuildTool name constraints) ->
     installOnPath (InstallPackageName name) constraints
-


### PR DESCRIPTION
In the early days we savagely pulled the package-id out of cabal files using a combination of `Data.Text` hacks in order to avoid pulling in `Cabal` as a dependency. Now we have `Cabal` as a dependency we might as well use the proper parser.

I was working with a `.cabal` file where our string savagery didn't work (below),  so I thought we should fix this properly.

```
package:
  foo
version:
  1.2.3
...
```

! @charleso 
/jury approved @charleso