### PR TITLE
REALLY kill cabal on ctrl-c

### DIFF
--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -469,7 +469,7 @@ mafiaBuild p w dump flags args = do
 mafiaTest :: [Flag] -> [Argument] -> EitherT MafiaError IO ()
 mafiaTest flags args = do
   initMafia DisableProfiling flags
-  liftCabal . cabal_ "test" $ ["-j", "--show-details=streaming"] <> args
+  liftCabal . cabalAnnihilate "test" $ ["-j", "--show-details=streaming"] <> args
 
 mafiaTestCI :: [Flag] -> [Argument] -> EitherT MafiaError IO ()
 mafiaTestCI flags args = do
@@ -485,7 +485,7 @@ mafiaRepl flags args = do
 mafiaBench :: [Flag] -> [Argument] -> EitherT MafiaError IO ()
 mafiaBench flags args = do
   initMafia DisableProfiling flags
-  liftCabal $ cabal_ "bench" args
+  liftCabal $ cabalAnnihilate "bench" args
 
 mafiaLock :: [Flag] -> EitherT MafiaError IO ()
 mafiaLock flags = do

--- a/src/Mafia/Cabal/Process.hs
+++ b/src/Mafia/Cabal/Process.hs
@@ -28,7 +28,7 @@ cabal cmd args = call CabalProcessError "cabal" (cmd : args)
 
 cabal_ :: Argument -> [Argument] -> EitherT CabalError IO ()
 cabal_ cmd args = do
-  PassErr <- cabal cmd args
+  PassErrAnnihilate <- cabal cmd args
   return ()
 
 cabalFrom ::

--- a/src/Mafia/Cabal/Process.hs
+++ b/src/Mafia/Cabal/Process.hs
@@ -3,6 +3,7 @@
 module Mafia.Cabal.Process
   ( cabal
   , cabal_
+  , cabalAnnihilate
   , cabalFrom
   ) where
 
@@ -28,8 +29,14 @@ cabal cmd args = call CabalProcessError "cabal" (cmd : args)
 
 cabal_ :: Argument -> [Argument] -> EitherT CabalError IO ()
 cabal_ cmd args = do
+  PassErr <- cabal cmd args
+  return ()
+
+cabalAnnihilate :: Argument -> [Argument] -> EitherT CabalError IO ()
+cabalAnnihilate cmd args = do
   PassErrAnnihilate <- cabal cmd args
   return ()
+
 
 cabalFrom ::
   ProcessResult a =>

--- a/src/Mafia/Process.hs
+++ b/src/Mafia/Process.hs
@@ -206,7 +206,9 @@ tryProcessGroupOfProcessHandle ph = do
   pid <- tryPosixPidOfProcessHandle ph
   case pid of
    Nothing -> return Nothing
-   Just h  -> handle ignoreIOE (Just <$> liftIO (Posix.getProcessGroupIDOf h))
+   Just h  -> handle ignoreIOE $ do
+    pgid <- liftIO (Posix.getProcessGroupIDOf h)
+    return $ Just pgid
  where
   ignoreIOE (_ :: IOException) = return Nothing
 

--- a/src/Mafia/Process.hs
+++ b/src/Mafia/Process.hs
@@ -209,7 +209,8 @@ createProcessAnnihilate cp = do
       let ignoreIOE (_ :: IOException) = return Nothing
       handle ignoreIOE (Just <$> Posix.getProcessGroupIDOf h)
 
-  killer = Signals.signalProcessGroup Signals.killProcess
+  -- SIGQUIT
+  killer = Signals.signalProcessGroup Signals.keyboardTermination
 
 
 class ProcessResult a where


### PR DESCRIPTION
Now:
```
amos@Amos mafia $ mafia test
Preprocessing library ambiata-mafia-0.0.1...
Preprocessing test suite 'test' for ambiata-mafia-0.0.1...
Preprocessing test suite 'test-io' for ambiata-mafia-0.0.1...
Preprocessing test suite 'test-cli' for ambiata-mafia-0.0.1...
Running 3 test suites...
Test suite test: RUNNING...
=== prop_roundtrip_Constraint from test/Test/Mafia/Cabal/Constraint.hs:19 ===
+++ OK, passed 100 tests.
^CProcess failed: cabal test -j --show-details=streaming (exit code: -9)
```

Before:
```
amos@Amos mafia $ mafia test
Preprocessing library ambiata-mafia-0.0.1...
Preprocessing test suite 'test' for ambiata-mafia-0.0.1...
Preprocessing test suite 'test-io' for ambiata-mafia-0.0.1...
Preprocessing test suite 'test-cli' for ambiata-mafia-0.0.1...
Running 3 test suites...
Test suite test: RUNNING...
=== prop_roundtrip_Constraint from test/Test/Mafia/Cabal/Constraint.hs:19 ===
+++ OK, passed 100 tests.

^C
amos@Amos mafia $
=== prop_roundtrip_PackagePlan from test/Test/Mafia/Cabal/Dependencies.hs:20 ===
+++ OK, passed 100 tests.

=== prop_roundtrip_Flag from test/Test/Mafia/Cabal/Types.hs:19 ===
+++ OK, passed 100 tests.

^C
amos@Amos mafia $
^C
^C

=== prop_joinHooglePackages from test/Test/Mafia/Hoogle.hs:16 ===
+++ OK, passed 1 tests.

=== prop_roundtrip_PackageId from test/Test/Mafia/Package.hs:19 ===
+++ OK, passed 100 tests.

=== prop_clean from test/Test/Mafia/Process.hs:14 ===
+++ OK, passed 100 tests.

Test suite test: PASS
Test suite logged to: dist/test/ambiata-mafia-0.0.1-test.log
Test suite test-io: RUNNING...
=== prop_flock from test/Test/IO/Mafia/Flock.hs:30 ===

^C
^C
=== prop_roundtrip_PackagePlan from test/Test/Mafia/Cabal/Dependencies.hs:20 ===
+++ OK, passed 100 tests.

=== prop_roundtrip_Flag from test/Test/Mafia/Cabal/Types.hs:19 ===
+++ OK, passed 100 tests.

```
/jury approved @tranma @olorin @erikd-ambiata @jystic