### PR TITLE
Add finite backjump limit

### DIFF
--- a/src/Mafia/Cabal/Dependencies.hs
+++ b/src/Mafia/Cabal/Dependencies.hs
@@ -190,7 +190,10 @@ makeInstallPlan mdir sourcePkgs installArgs = do
       installDryRun args =
         cabal "install" $
           [ "--reorder-goals"
-          , "--max-backjumps=-1"
+            -- 10^3 is an arbitrary "should be enough for anyone" number,
+            -- used rather than -1 to avoid running forever in build scripts
+            -- et cetera.
+          , "--max-backjumps=1000"
           , "--avoid-reinstalls"
           , "--dry-run" ] <> installArgs <> args
 


### PR DESCRIPTION
No limit by default is problematic because it makes identifying
nonterminating searches require more effort ("dependency resolution is
taking ages, is it just really slow due to hardware/load/gremlins or
is there another problem?")

I think this should be configurable; I made a start on implementing
this in `topic/term2`, but it's not ready yet so I thought I would put
this up in the interim.

! @nhibberd @jystic