### PR TITLE
Cache everything, even source packages

### DIFF
--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -91,7 +91,7 @@ data MafiaCommand =
   | MafiaWatch [Flag] [GhciInclude] File [Argument]
   | MafiaHoogle [Argument]
   | MafiaInstall [Constraint] InstallPackage
-  | MafiaExport Profiling [Flag] Directory
+  | MafiaExport [Flag] Directory
   | MafiaImport Directory
   | MafiaScript Path [Argument]
   | MafiaExec [Argument]
@@ -151,8 +151,8 @@ run = \case
     mafiaHoogle args
   MafiaInstall constraints ipkg ->
     mafiaInstall ipkg constraints
-  MafiaExport p flags dir ->
-    mafiaExport p flags dir
+  MafiaExport flags dir ->
+    mafiaExport flags dir
   MafiaImport dir ->
     mafiaImport dir
   MafiaScript path args ->
@@ -234,7 +234,7 @@ commands =
             (MafiaInstall <$> many pConstraint <*> pInstallPackage)
 
  , command' "export" "Export binary substitutes of the current package's dependencies."
-            (MafiaExport <$> pProfiling <*> many pFlag <*> pExportDirectory)
+            (MafiaExport <$> many pFlag <*> pExportDirectory)
 
  , command' "import" "Import binary substitutes from a directory."
             (MafiaImport <$> pImportDirectory)
@@ -554,9 +554,9 @@ mafiaInstall :: InstallPackage -> [Constraint] -> EitherT MafiaError IO ()
 mafiaInstall ipkg constraints = do
   liftIO . T.putStrLn =<< firstT MafiaBinError (installBinary ipkg constraints)
 
-mafiaExport :: Profiling -> [Flag] -> Directory -> EitherT MafiaError IO ()
-mafiaExport p flags dir = do
-  initMafia LatestSources p flags
+mafiaExport :: [Flag] -> Directory -> EitherT MafiaError IO ()
+mafiaExport flags dir = do
+  initMafia LatestSources DisableProfiling flags
   mkeys <- firstT MafiaInitError readPackageKeys
   case mkeys of
     Nothing ->

--- a/src/Mafia/Init.hs
+++ b/src/Mafia/Init.hs
@@ -142,15 +142,20 @@ initialize dfilter mprofiling mflags = do
     installed <- firstT InitInstallError $ installDependencies flavours flags sdeps constraints
 
     let
+      allPkgs =
+        Set.toList installed
+
       -- Note that we filter out source packages. Storing their version in the
       -- constraints file is redundant, as the accessible source code is the only
       -- version of that package which is ever available for installation.
       hackagePkgs =
-        filter (isNothing . refSrcPkg . pkgRef) $
-        Set.toList installed
+        filter (isNothing . refSrcPkg . pkgRef) allPkgs
 
-    writeInstallConstraints $ concatMap (packageRefConstraints . pkgRef) hackagePkgs
-    writePackageKeys $ fmap pkgKey hackagePkgs
+    writePackageKeys $
+      fmap pkgKey allPkgs
+
+    writeInstallConstraints $
+      concatMap (packageRefConstraints . pkgRef) hackagePkgs
 
   let needConfigure = needInstall || not hasSetupConfig
 


### PR DESCRIPTION
This might be OK as long as we don't do profiling builds.