### PR TITLE
Update ghcid to handle 8+ CallStack changes.

### DIFF
--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -560,7 +560,7 @@ mafiaQuick flags extraIncludes paths = do
 
 mafiaWatch :: [Flag] -> [GhciInclude] -> File -> [Argument] -> EitherT MafiaError IO ()
 mafiaWatch flags extraIncludes path extraArgs = do
-  ghcidExe <- bimapT MafiaBinError (</> "ghcid") $ installBinary (ipackageId "ghcid" [0, 5]) []
+  ghcidExe <- bimapT MafiaBinError (</> "ghcid") $ installBinary (ipackageId "ghcid" [0, 6, 7]) []
   dir <- getWorkingDirectory $ Just path
   args <- ghciArgs dir extraIncludes [path]
   withDirectory dir $ initMafia (vintageOfIncludes extraIncludes) DisableProfiling flags


### PR DESCRIPTION
Without this, running commands with mafia watch results
in call stacks being printed from how ghcid escapes out
of ghci with 'error' calls.

Having these versions hardcoded is less than ideal, it 
assumes people have the same hackage index and the
same version will always work across versions which is
not true. Leaving that as is for the moment, but I will 
update if this new version causes issues anywhere.

