### PR TITLE
[Do not merge]: Drop special case handling of lib directory

### DIFF
--- a/src/Mafia/Submodule.hs
+++ b/src/Mafia/Submodule.hs
@@ -136,7 +136,6 @@ getSourcesFrom dir = do
            . fmap   (takeDirectory)
            . filter (not . T.isInfixOf ".cabal-sandbox/")
            . filter (not . T.isPrefixOf "dist-newstyle/")
-           . filter (not . T.isPrefixOf "lib/")
            . filter (not . T.isPrefixOf "bin/")
            . filter (extension ".cabal")
            . fmap   (T.drop (T.length dir' + 1))


### PR DESCRIPTION
I can't see any reason why the `lib` directory should be special. I'm also using mafia to build a project that has a cabal file in the `lib/` directory.

! @jystic @tmcgilchrist 