### PR TITLE
Inline Twine.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/disorder"]
-	path = lib/disorder
-	url = https://github.com/ambiata/disorder.hs

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,6 @@
 [submodule "lib/x"]
 	path = lib/x
 	url = https://github.com/haskell-mafia/x
-
+[submodule "lib/p"]
+	path = lib/p
+	url = git@github.com:ambiata/p.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,4 @@
 [submodule "lib/x"]
 	path = lib/x
 	url = https://github.com/haskell-mafia/x
-[submodule "lib/twine"]
-	path = lib/twine
-	url = https://github.com/haskell-mafia/twine
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "lib/p"]
-	path = lib/p
-	url = https://github.com/ambiata/p
 [submodule "lib/disorder"]
 	path = lib/disorder
 	url = https://github.com/haskell-mafia/disorder.hs

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,3 @@
 [submodule "lib/disorder"]
 	path = lib/disorder
-	url = https://github.com/haskell-mafia/disorder.hs
-[submodule "lib/x"]
-	path = lib/x
-	url = https://github.com/haskell-mafia/x
-[submodule "lib/p"]
-	path = lib/p
-	url = git@github.com:ambiata/p.git
+	url = https://github.com/ambiata/disorder.hs

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,6 @@ install:
 
  # These sandbox commands are doing manually what mafia would do when building itself.
  - cabal sandbox init
- - cabal sandbox add-source lib/disorder/disorder-core
- - cabal sandbox add-source lib/disorder/disorder-corpus
 
 script:
  - cabal install --dependencies-only --enable-tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,6 @@ install:
  - cabal sandbox init
  - cabal sandbox add-source lib/disorder/disorder-core
  - cabal sandbox add-source lib/disorder/disorder-corpus
- - cabal sandbox add-source lib/p
- - cabal sandbox add-source lib/twine
- - cabal sandbox add-source lib/x/x-eithert
- - cabal sandbox add-source lib/x/x-exception
- - cabal sandbox add-source lib/x/x-optparse
 
 script:
  - cabal install --dependencies-only --enable-tests

--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -16,7 +16,6 @@ library
                       base                            >= 3          && < 5
                     , ambiata-p
                     , ambiata-x-eithert
-                    , ambiata-twine
                     , aeson                           >= 0.8        && < 0.12
                     , async                           >= 2.0        && < 2.2
                     , attoparsec                      >= 0.12       && < 0.14
@@ -30,10 +29,12 @@ library
                     , exceptions                      == 0.8.*
                     , filelock                        == 0.1.*
                     , filepath                        == 1.4.*
+                    , monad-loops                     == 0.4.*
                     , memory                          >= 0.12       && < 0.15
                     , parallel                        == 3.2.*
                     , process                         >= 1.4        && < 1.5
                     , retry                           == 0.7.*
+                    , SafeSemaphore                   == 0.10.*
                     , stm                             == 2.4.*
                     , tar                             == 0.4.*
                     , temporary                       == 1.2.*
@@ -84,6 +85,11 @@ library
                     Mafia.Script
                     Mafia.Submodule
                     Mafia.Tree
+                    Mafia.Twine
+                    Mafia.Twine.Async
+                    Mafia.Twine.Parallel
+                    Mafia.Twine.Queue
+                    Mafia.Twine.Snooze
                     Paths_ambiata_mafia
 
 executable mafia

--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -27,7 +27,7 @@ library
                     , exceptions                      == 0.8.*
                     , filelock                        == 0.1.*
                     , filepath                        == 1.4.*
-                    , ghc-prim                        == 0.5.*
+                    , ghc-prim                        >= 0.4.0      && <= 0.6
                     , monad-loops                     == 0.4.*
                     , memory                          >= 0.12       && < 0.15
                     , optparse-applicative            >= 0.11       && < 0.15
@@ -111,10 +111,6 @@ executable mafia
                     BuildInfo_ambiata_mafia
                     DependencyInfo_ambiata_mafia
 
-  autogen-modules:
-                    BuildInfo_ambiata_mafia
-                    DependencyInfo_ambiata_mafia
-
   build-depends:
                       base
                     , ambiata-mafia
@@ -151,6 +147,9 @@ test-suite test
                     Test.Mafia.Hoogle
                     Test.Mafia.Package
                     Test.Mafia.Process
+                    Test.Mafia.Corpus
+                    Test.Mafia.Main
+                    Test.Mafia.Tripping
 
   build-depends:
                       base                            >= 3          && < 5
@@ -182,6 +181,9 @@ test-suite test-io
   other-modules:
                     Test.IO.Mafia.Chaos
                     Test.IO.Mafia.Flock
+                    Test.Mafia.IO
+                    Test.Mafia.Corpus
+                    Test.Mafia.Main
 
   build-depends:
                       base                            >= 3          && < 5
@@ -206,6 +208,10 @@ test-suite test-cli
   main-is:
                     test-cli.hs
 
+  other-modules:
+                    Test.Mafia.IO
+                    Test.Mafia.Main
+
   ghc-options:
                     -Wall -threaded -O2
 
@@ -217,3 +223,5 @@ test-suite test-cli
                     , ambiata-mafia
                     , directory                       >= 1.2        && < 1.4
                     , process                         >= 1.2        && < 1.5
+                    , QuickCheck                      == 2.8.*
+                    , transformers

--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -154,9 +154,9 @@ test-suite test
 
   build-depends:
                       base                            >= 3          && < 5
-                    , ambiata-disorder-core
-                    , ambiata-disorder-corpus
                     , ambiata-mafia
+                    , directory                       >= 1.2        && < 1.4
+                    , process                         >= 1.2        && < 1.5
                     , QuickCheck                      == 2.8.*
                     , quickcheck-instances            == 0.3.*
                     , text
@@ -185,12 +185,12 @@ test-suite test-io
 
   build-depends:
                       base                            >= 3          && < 5
-                    , ambiata-disorder-core
-                    , ambiata-disorder-corpus
                     , ambiata-mafia
                     , async                           >= 2.0        && < 2.2
                     , containers                      == 0.5.*
+                    , directory                       >= 1.2        && < 1.4
                     , exceptions                      == 0.8.*
+                    , process                         >= 1.2        && < 1.5
                     , QuickCheck                      == 2.8.*
                     , quickcheck-instances            == 0.3.*
                     , temporary                       == 1.2.*
@@ -214,5 +214,6 @@ test-suite test-cli
 
   build-depends:
                       base                            >= 3          && < 5
-                    , ambiata-disorder-core
                     , ambiata-mafia
+                    , directory                       >= 1.2        && < 1.4
+                    , process                         >= 1.2        && < 1.5

--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -14,7 +14,6 @@ description:           mafia
 library
   build-depends:
                       base                            >= 3          && < 5
-                    , ambiata-p
                     , ambiata-x-eithert
                     , aeson                           >= 0.8        && < 0.12
                     , async                           >= 2.0        && < 2.2
@@ -44,6 +43,7 @@ library
                     , time-locale-compat              == 0.1.*
                     , transformers                    >= 0.4        && < 0.6
                     , transformers-bifunctors         == 0.1.*
+                    , transformers-either             == 0.0.1
                     , unix                            == 2.7.*
 
   ghc-options:
@@ -68,6 +68,7 @@ library
                     Mafia.Cabal.Types
                     Mafia.Cabal.Version
                     Mafia.Cache
+                    Mafia.Catch
                     Mafia.Error
                     Mafia.Flock
                     Mafia.Ghc
@@ -157,7 +158,6 @@ test-suite test
                     , ambiata-disorder-core
                     , ambiata-disorder-corpus
                     , ambiata-mafia
-                    , ambiata-p
                     , ambiata-x-eithert
                     , QuickCheck                      == 2.8.*
                     , quickcheck-instances            == 0.3.*
@@ -190,7 +190,6 @@ test-suite test-io
                     , ambiata-disorder-core
                     , ambiata-disorder-corpus
                     , ambiata-mafia
-                    , ambiata-p
                     , ambiata-x-eithert
                     , async                           >= 2.0        && < 2.2
                     , containers                      == 0.5.*
@@ -200,6 +199,8 @@ test-suite test-io
                     , temporary                       == 1.2.*
                     , text                            == 1.2.*
                     , transformers                    >= 0.4        && < 0.6
+                    , transformers-bifunctors
+                    , transformers-either
 
 test-suite test-cli
   type:

--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -29,6 +29,7 @@ library
                     , exceptions                      == 0.8.*
                     , filelock                        == 0.1.*
                     , filepath                        == 1.4.*
+                    , ghc-prim                        == 0.5.*
                     , monad-loops                     == 0.4.*
                     , memory                          >= 0.12       && < 0.15
                     , parallel                        == 3.2.*
@@ -42,6 +43,7 @@ library
                     , time                            >= 1.4        && < 1.9
                     , time-locale-compat              == 0.1.*
                     , transformers                    >= 0.4        && < 0.6
+                    , transformers-bifunctors         == 0.1.*
                     , unix                            == 2.7.*
 
   ghc-options:
@@ -79,6 +81,7 @@ library
                     Mafia.Install
                     Mafia.Lock
                     Mafia.Makefile
+                    Mafia.P
                     Mafia.Package
                     Mafia.Path
                     Mafia.Process

--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -5,11 +5,26 @@ license-file:          LICENSE
 author:                Ambiata <info@ambiata.com>
 maintainer:            Ambiata <info@ambiata.com>
 copyright:             (c) 2015 Ambiata.
+homepage:              https://github.com/haskell-mafia/mafia
+Bug-reports:           https://github.com/haskell-mafia/mafia/issues
 synopsis:              mafia
 category:              Development
-cabal-version:         >= 1.8
+cabal-version:         >= 1.24
 build-type:            Custom
-description:           mafia
+description:           Mafia is a light weight but opinionated wrapper around Cabal that makes working
+                       on Haskell projects fun and easy.
+
+extra-source-files:
+  README.md
+
+source-repository head
+  type: git
+  location: https://github.com/haskell-mafia/mafia.git
+
+custom-setup
+  setup-depends:
+                      base  >= 4.5 && < 5
+                    , Cabal >= 1.24 && < 2.1
 
 library
   build-depends:
@@ -46,6 +61,8 @@ library
                     , transformers-either             == 0.0.1
                     , unix                            == 2.7.*
 
+  default-language:
+                    Haskell2010
   ghc-options:
                     -Wall
 
@@ -98,18 +115,17 @@ library
                     Paths_ambiata_mafia
 
 executable mafia
+  default-language:
+                    Haskell2010
+
   ghc-options:
-                    -Wall -threaded -O2
+                    -Wall
 
   hs-source-dirs:
                     gen
 
   main-is:
                     ../main/mafia.hs
-
-  other-modules:
-                    BuildInfo_ambiata_mafia
-                    DependencyInfo_ambiata_mafia
 
   build-depends:
                       base
@@ -133,8 +149,11 @@ test-suite test
   main-is:
                     test.hs
 
+  default-language:
+                    Haskell2010
+
   ghc-options:
-                    -Wall -threaded -O2
+                    -Wall
 
   hs-source-dirs:
                     test
@@ -168,8 +187,11 @@ test-suite test-io
   main-is:
                     test-io.hs
 
+  default-language:
+                    Haskell2010
+
   ghc-options:
-                    -Wall -threaded -O2
+                    -Wall
 
   if impl(ghc >= 8.0)
     ghc-options:
@@ -212,8 +234,11 @@ test-suite test-cli
                     Test.Mafia.IO
                     Test.Mafia.Main
 
+  default-language:
+                    Haskell2010
+
   ghc-options:
-                    -Wall -threaded -O2
+                    -Wall
 
   hs-source-dirs:
                     test

--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -14,7 +14,6 @@ description:           mafia
 library
   build-depends:
                       base                            >= 3          && < 5
-                    , ambiata-x-eithert
                     , aeson                           >= 0.8        && < 0.12
                     , async                           >= 2.0        && < 2.2
                     , attoparsec                      >= 0.12       && < 0.14
@@ -31,6 +30,7 @@ library
                     , ghc-prim                        == 0.5.*
                     , monad-loops                     == 0.4.*
                     , memory                          >= 0.12       && < 0.15
+                    , optparse-applicative            >= 0.11       && < 0.15
                     , parallel                        == 3.2.*
                     , process                         >= 1.4        && < 1.5
                     , retry                           == 0.7.*
@@ -82,6 +82,7 @@ library
                     Mafia.Install
                     Mafia.Lock
                     Mafia.Makefile
+                    Mafia.Options.Applicative
                     Mafia.P
                     Mafia.Package
                     Mafia.Path
@@ -117,9 +118,6 @@ executable mafia
   build-depends:
                       base
                     , ambiata-mafia
-                    , ambiata-p
-                    , ambiata-x-eithert
-                    , ambiata-x-optparse
                     , bytestring                      == 0.10.*
                     , containers                      == 0.5.*
                     , directory                       >= 1.2        && < 1.4
@@ -129,7 +127,8 @@ executable mafia
                     , time                            >= 1.4        && < 1.9
                     , time-locale-compat              == 0.1.*
                     , transformers                    >= 0.4        && < 0.6
-
+                    , transformers-bifunctors         == 0.1.*
+                    , transformers-either             == 0.0.1
 
 test-suite test
   type:
@@ -158,7 +157,6 @@ test-suite test
                     , ambiata-disorder-core
                     , ambiata-disorder-corpus
                     , ambiata-mafia
-                    , ambiata-x-eithert
                     , QuickCheck                      == 2.8.*
                     , quickcheck-instances            == 0.3.*
                     , text
@@ -190,7 +188,6 @@ test-suite test-io
                     , ambiata-disorder-core
                     , ambiata-disorder-corpus
                     , ambiata-mafia
-                    , ambiata-x-eithert
                     , async                           >= 2.0        && < 2.2
                     , containers                      == 0.5.*
                     , exceptions                      == 0.8.*

--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -39,19 +39,20 @@ import           Mafia.Script
 import           Mafia.Submodule
 import           Mafia.Tree
 
-import           P hiding (Last)
+import           Mafia.P
 
 import           System.Environment (getArgs)
 import           System.IO (BufferMode(..), hSetBuffering)
 import           System.IO (IO, FilePath, stdout, stderr)
 
-import           X.Control.Monad.Trans.Either (EitherT, hoistEither, left)
-import           X.Control.Monad.Trans.Either.Exit (orDie)
-import           X.Options.Applicative (Parser, CommandFields, Mod, ReadM)
-import           X.Options.Applicative (action, argument, textRead, metavar, help, long, short)
-import           X.Options.Applicative (option, flag, flag', eitherTextReader, eitherReader)
-import           X.Options.Applicative (cli, subparser, command')
+import           Control.Monad.Trans.Either (EitherT, hoistEither, left)
+import           Control.Monad.Trans.Bifunctor (firstT, bimapT)
 
+import           Mafia.Options.Applicative (Parser, CommandFields, Mod, ReadM)
+import           Mafia.Options.Applicative (action, argument, textRead
+                                     , metavar, help, long, short)
+import           Mafia.Options.Applicative (option, flag, flag', eitherTextReader, eitherReader)
+import           Mafia.Options.Applicative (cli, subparser, command', orDie)
 
 ------------------------------------------------------------------------
 

--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -8,7 +8,6 @@ import           BuildInfo_ambiata_mafia
 import           DependencyInfo_ambiata_mafia
 
 import           Control.Concurrent (setNumCapabilities)
-import           Control.Monad.IO.Class (MonadIO(..))
 
 import           Data.ByteString (ByteString)
 import qualified Data.List as List

--- a/src/Mafia/Bin.hs
+++ b/src/Mafia/Bin.hs
@@ -31,7 +31,7 @@ import           Mafia.P
 
 import           System.IO (IO)
 
-import           X.Control.Monad.Trans.Either (EitherT, left)
+import           Control.Monad.Trans.Either (EitherT, left)
 import           Control.Monad.Trans.Bifunctor
 
 data BinError =

--- a/src/Mafia/Bin.hs
+++ b/src/Mafia/Bin.hs
@@ -16,6 +16,9 @@ module Mafia.Bin
   , installOnPath
   ) where
 
+import           Control.Monad.Trans.Either (EitherT, left)
+import           Control.Monad.Trans.Bifunctor (firstT)
+
 import           Mafia.Cabal.Constraint
 import           Mafia.Cabal.Sandbox
 import           Mafia.Cabal.Types
@@ -26,13 +29,9 @@ import           Mafia.Install
 import           Mafia.IO
 import           Mafia.Package
 import           Mafia.Path
-
 import           Mafia.P
 
 import           System.IO (IO)
-
-import           Control.Monad.Trans.Either (EitherT, left)
-import           Control.Monad.Trans.Bifunctor
 
 data BinError =
     BinInstallError InstallError

--- a/src/Mafia/Bin.hs
+++ b/src/Mafia/Bin.hs
@@ -27,12 +27,12 @@ import           Mafia.IO
 import           Mafia.Package
 import           Mafia.Path
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 
 import           X.Control.Monad.Trans.Either (EitherT, left)
-
+import           Control.Monad.Trans.Bifunctor
 
 data BinError =
     BinInstallError InstallError

--- a/src/Mafia/Cabal/Constraint.hs
+++ b/src/Mafia/Cabal/Constraint.hs
@@ -15,10 +15,9 @@ module Mafia.Cabal.Constraint (
 import qualified Data.Text as T
 
 import           Mafia.Cabal.Types
+import           Mafia.P
 import           Mafia.Package
 import           Mafia.Process
-
-import           Mafia.P
 
 data Constraint =
     ConstraintPackage !PackageName !Version

--- a/src/Mafia/Cabal/Constraint.hs
+++ b/src/Mafia/Cabal/Constraint.hs
@@ -18,8 +18,7 @@ import           Mafia.Cabal.Types
 import           Mafia.Package
 import           Mafia.Process
 
-import           P
-
+import           Mafia.P
 
 data Constraint =
     ConstraintPackage !PackageName !Version

--- a/src/Mafia/Cabal/Dependencies.hs
+++ b/src/Mafia/Cabal/Dependencies.hs
@@ -16,7 +16,8 @@ module Mafia.Cabal.Dependencies
   , renderPackagePlan
   ) where
 
-import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Trans.Bifunctor (firstT)
+import           Control.Monad.Trans.Either (EitherT, hoistEither, runEitherT, left)
 
 import           Data.Attoparsec.Text (Parser)
 import qualified Data.Attoparsec.Text as A
@@ -37,16 +38,12 @@ import           Mafia.Cabal.Types
 import           Mafia.Cabal.Version
 import           Mafia.Ghc
 import           Mafia.IO
+import           Mafia.P
 import           Mafia.Package
 import           Mafia.Path
 import           Mafia.Process
 
-import           Mafia.P
-
 import           System.IO (IO)
-
-import           Control.Monad.Trans.Either
-import           Control.Monad.Trans.Bifunctor
 
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Cabal/Dependencies.hs
+++ b/src/Mafia/Cabal/Dependencies.hs
@@ -41,12 +41,12 @@ import           Mafia.Package
 import           Mafia.Path
 import           Mafia.Process
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 
 import           X.Control.Monad.Trans.Either
-
+import           Control.Monad.Trans.Bifunctor
 
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Cabal/Dependencies.hs
+++ b/src/Mafia/Cabal/Dependencies.hs
@@ -238,8 +238,8 @@ pPackagePlans = do
 pDropLines :: Text -> Parser ()
 pDropLines target =
   let go = do
-      l <- A.takeWhile (/= '\n') <* A.char '\n'
-      unless (l == target) go
+          l <- A.takeWhile (/= '\n') <* A.char '\n'
+          unless (l == target) go
   in go
 
 pPackagePlan :: Parser PackagePlan

--- a/src/Mafia/Cabal/Dependencies.hs
+++ b/src/Mafia/Cabal/Dependencies.hs
@@ -45,7 +45,7 @@ import           Mafia.P
 
 import           System.IO (IO)
 
-import           X.Control.Monad.Trans.Either
+import           Control.Monad.Trans.Either
 import           Control.Monad.Trans.Bifunctor
 
 ------------------------------------------------------------------------

--- a/src/Mafia/Cabal/Index.hs
+++ b/src/Mafia/Cabal/Index.hs
@@ -28,7 +28,7 @@ import qualified Prelude as Prelude
 
 import           System.IO (IO)
 
-import           X.Control.Monad.Trans.Either (EitherT, hoistEither)
+import           Control.Monad.Trans.Either (EitherT, hoistEither)
 
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Cabal/Index.hs
+++ b/src/Mafia/Cabal/Index.hs
@@ -22,7 +22,7 @@ import           Mafia.Cabal.Types
 import           Mafia.IO
 import           Mafia.Path
 
-import           P
+import           Mafia.P
 
 import qualified Prelude as Prelude
 

--- a/src/Mafia/Cabal/Index.hs
+++ b/src/Mafia/Cabal/Index.hs
@@ -9,7 +9,7 @@ module Mafia.Cabal.Index
 
 import           Control.Exception (IOException)
 import           Control.Monad.Catch (catch)
-import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Trans.Either (EitherT, hoistEither)
 
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as L
@@ -21,14 +21,11 @@ import qualified Codec.Archive.Tar.Entry as Tar
 import           Mafia.Cabal.Types
 import           Mafia.IO
 import           Mafia.Path
-
 import           Mafia.P
 
 import qualified Prelude as Prelude
 
 import           System.IO (IO)
-
-import           Control.Monad.Trans.Either (EitherT, hoistEither)
 
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Cabal/Package.hs
+++ b/src/Mafia/Cabal/Package.hs
@@ -59,7 +59,7 @@ import           Mafia.P
 
 import           System.IO (IO)
 
-import           X.Control.Monad.Trans.Either (EitherT, left, runEitherT)
+import           Control.Monad.Trans.Either (EitherT, left, runEitherT)
 import           Control.Monad.Trans.Bifunctor (firstT)
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Cabal/Package.hs
+++ b/src/Mafia/Cabal/Package.hs
@@ -21,7 +21,8 @@ module Mafia.Cabal.Package (
   , hashSourcePackage
   ) where
 
-import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Trans.Bifunctor (firstT)
+import           Control.Monad.Trans.Either (EitherT, left, runEitherT)
 
 import qualified Data.List as List
 import           Data.Set (Set)
@@ -54,13 +55,10 @@ import           Mafia.IO
 import           Mafia.Package
 import           Mafia.Path
 import           Mafia.Process
-
 import           Mafia.P
 
 import           System.IO (IO)
 
-import           Control.Monad.Trans.Either (EitherT, left, runEitherT)
-import           Control.Monad.Trans.Bifunctor (firstT)
 ------------------------------------------------------------------------
 
 getCabalFile :: Directory -> EitherT CabalError IO File

--- a/src/Mafia/Cabal/Package.hs
+++ b/src/Mafia/Cabal/Package.hs
@@ -55,12 +55,12 @@ import           Mafia.Package
 import           Mafia.Path
 import           Mafia.Process
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 
 import           X.Control.Monad.Trans.Either (EitherT, left, runEitherT)
-
+import           Control.Monad.Trans.Bifunctor (firstT)
 ------------------------------------------------------------------------
 
 getCabalFile :: Directory -> EitherT CabalError IO File

--- a/src/Mafia/Cabal/Process.hs
+++ b/src/Mafia/Cabal/Process.hs
@@ -7,22 +7,19 @@ module Mafia.Cabal.Process
   , cabalFrom
   ) where
 
-import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Trans.Bifunctor (firstT)
+import           Control.Monad.Trans.Either (EitherT)
 
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Text as T
 
 import           Mafia.Cabal.Types
-import           Mafia.Process
 import           Mafia.IO (getEnvironment)
-
 import           Mafia.P
+import           Mafia.Process
 
 import           System.IO (IO)
-
-import           Control.Monad.Trans.Either (EitherT)
-import           Control.Monad.Trans.Bifunctor (firstT)
 
 cabal :: ProcessResult a => Argument -> [Argument] -> EitherT CabalError IO a
 cabal cmd args = call CabalProcessError "cabal" (cmd : args)
@@ -36,7 +33,6 @@ cabalAnnihilate :: Argument -> [Argument] -> EitherT CabalError IO ()
 cabalAnnihilate cmd args = do
   PassErrAnnihilate <- cabal cmd args
   return ()
-
 
 cabalFrom ::
   ProcessResult a =>

--- a/src/Mafia/Cabal/Process.hs
+++ b/src/Mafia/Cabal/Process.hs
@@ -17,12 +17,12 @@ import           Mafia.Cabal.Types
 import           Mafia.Process
 import           Mafia.IO (getEnvironment)
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 
 import           X.Control.Monad.Trans.Either (EitherT)
-
+import           Control.Monad.Trans.Bifunctor (firstT)
 
 cabal :: ProcessResult a => Argument -> [Argument] -> EitherT CabalError IO a
 cabal cmd args = call CabalProcessError "cabal" (cmd : args)

--- a/src/Mafia/Cabal/Process.hs
+++ b/src/Mafia/Cabal/Process.hs
@@ -21,7 +21,7 @@ import           Mafia.P
 
 import           System.IO (IO)
 
-import           X.Control.Monad.Trans.Either (EitherT)
+import           Control.Monad.Trans.Either (EitherT)
 import           Control.Monad.Trans.Bifunctor (firstT)
 
 cabal :: ProcessResult a => Argument -> [Argument] -> EitherT CabalError IO a

--- a/src/Mafia/Cabal/Sandbox.hs
+++ b/src/Mafia/Cabal/Sandbox.hs
@@ -24,12 +24,12 @@ import           Mafia.IO
 import           Mafia.Path
 import           Mafia.Process
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 
 import           X.Control.Monad.Trans.Either (EitherT, runEitherT, left)
-
+import           Control.Monad.Trans.Bifunctor (firstT)
 
 sandbox :: ProcessResult a => Argument -> [Argument] -> EitherT CabalError IO a
 sandbox cmd args = do

--- a/src/Mafia/Cabal/Sandbox.hs
+++ b/src/Mafia/Cabal/Sandbox.hs
@@ -28,7 +28,7 @@ import           Mafia.P
 
 import           System.IO (IO)
 
-import           X.Control.Monad.Trans.Either (EitherT, runEitherT, left)
+import           Control.Monad.Trans.Either (EitherT, runEitherT, left)
 import           Control.Monad.Trans.Bifunctor (firstT)
 
 sandbox :: ProcessResult a => Argument -> [Argument] -> EitherT CabalError IO a

--- a/src/Mafia/Cabal/Sandbox.hs
+++ b/src/Mafia/Cabal/Sandbox.hs
@@ -12,7 +12,8 @@ module Mafia.Cabal.Sandbox
   , readPackageDB
   ) where
 
-import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Trans.Bifunctor (firstT)
+import           Control.Monad.Trans.Either (EitherT, runEitherT, left)
 
 import qualified Data.List as List
 import qualified Data.Text as T
@@ -23,13 +24,9 @@ import           Mafia.Ghc
 import           Mafia.IO
 import           Mafia.Path
 import           Mafia.Process
-
 import           Mafia.P
 
 import           System.IO (IO)
-
-import           Control.Monad.Trans.Either (EitherT, runEitherT, left)
-import           Control.Monad.Trans.Bifunctor (firstT)
 
 sandbox :: ProcessResult a => Argument -> [Argument] -> EitherT CabalError IO a
 sandbox cmd args = do

--- a/src/Mafia/Cabal/Types.hs
+++ b/src/Mafia/Cabal/Types.hs
@@ -45,7 +45,7 @@ import           Mafia.Package
 import           Mafia.Path
 import           Mafia.Process
 
-import           P
+import           Mafia.P
 
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Cabal/Types.hs
+++ b/src/Mafia/Cabal/Types.hs
@@ -41,11 +41,10 @@ import           Distribution.ParseUtils (locatedErrorMsg)
 
 import           Mafia.Ghc
 import           Mafia.Hash
+import           Mafia.P
 import           Mafia.Package
 import           Mafia.Path
 import           Mafia.Process
-
-import           Mafia.P
 
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Cabal/Version.hs
+++ b/src/Mafia/Cabal/Version.hs
@@ -19,7 +19,7 @@ import           Mafia.P
 
 import           System.IO (IO)
 
-import           X.Control.Monad.Trans.Either (EitherT, left, runEitherT)
+import           Control.Monad.Trans.Either (EitherT, left, runEitherT)
 
 
 getCabalVersion :: EitherT CabalError IO Version

--- a/src/Mafia/Cabal/Version.hs
+++ b/src/Mafia/Cabal/Version.hs
@@ -15,7 +15,7 @@ import           Mafia.Cabal.Types
 import           Mafia.Package
 import           Mafia.Process
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 

--- a/src/Mafia/Cabal/Version.hs
+++ b/src/Mafia/Cabal/Version.hs
@@ -6,7 +6,7 @@ module Mafia.Cabal.Version
   , checkCabalVersion
   ) where
 
-import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Trans.Either (EitherT, left, runEitherT)
 
 import qualified Data.Text as T
 
@@ -18,9 +18,6 @@ import           Mafia.Process
 import           Mafia.P
 
 import           System.IO (IO)
-
-import           Control.Monad.Trans.Either (EitherT, left, runEitherT)
-
 
 getCabalVersion :: EitherT CabalError IO Version
 getCabalVersion = do

--- a/src/Mafia/Cache.hs
+++ b/src/Mafia/Cache.hs
@@ -42,7 +42,8 @@ module Mafia.Cache (
   , listPackages
   ) where
 
-import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Trans.Bifunctor (firstT)
+import           Control.Monad.Trans.Either (EitherT, left, hoistEither)
 
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
@@ -53,16 +54,12 @@ import           Mafia.Ghc
 import           Mafia.Hash
 import           Mafia.Home
 import           Mafia.IO
+import           Mafia.P
 import           Mafia.Package
 import           Mafia.Path
 import           Mafia.Process
 
-import           Mafia.P
-
 import           System.IO (IO, stderr)
-
-import           Control.Monad.Trans.Either (EitherT, left, hoistEither)
-import           Control.Monad.Trans.Bifunctor
 
 data CacheEnv =
   CacheEnv {

--- a/src/Mafia/Cache.hs
+++ b/src/Mafia/Cache.hs
@@ -61,7 +61,7 @@ import           Mafia.P
 
 import           System.IO (IO, stderr)
 
-import           X.Control.Monad.Trans.Either (EitherT, left, hoistEither)
+import           Control.Monad.Trans.Either (EitherT, left, hoistEither)
 import           Control.Monad.Trans.Bifunctor
 
 data CacheEnv =

--- a/src/Mafia/Cache.hs
+++ b/src/Mafia/Cache.hs
@@ -57,12 +57,12 @@ import           Mafia.Package
 import           Mafia.Path
 import           Mafia.Process
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO, stderr)
 
 import           X.Control.Monad.Trans.Either (EitherT, left, hoistEither)
-
+import           Control.Monad.Trans.Bifunctor
 
 data CacheEnv =
   CacheEnv {

--- a/src/Mafia/Catch.hs
+++ b/src/Mafia/Catch.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE PatternSynonyms #-}
 module Mafia.Catch (
     Disaster(..)
   , bracketF
@@ -8,26 +9,18 @@ module Mafia.Catch (
   , bracketEitherT'
   ) where
 
-import           Control.Monad (return, liftM)
 import           Control.Monad.Catch (catchAll, throwM, handle)
 import           Control.Monad.Catch (Exception(..), SomeException(..))
 import           Control.Monad.Catch (MonadCatch(..), MonadMask(..))
+import           Control.Monad.Trans.Either (EitherT, runEitherT, pattern EitherT)
 
-import           Data.Bool (Bool(..))
-import           Data.Either (Either(..), either)
-import           Data.Eq (Eq(..))
-import           Data.Function (($), (.), const, id)
-import           Data.Maybe (Maybe(..))
-import           Data.Ord (Ord(..))
 import           Data.Typeable (typeOf)
 
 import           GHC.Show (appPrec)
 
 import           Mafia.P
 
-import           Text.Show (Show(..), showParen, showString, showChar)
-
-import           Control.Monad.Trans.Either
+import           Text.Show (showParen, showChar)
 
 -- | Newtype wrapper for 'SomeException' which provides an 'Eq' instance which
 --   says no two disasters are equal. It also provides a 'Show' instance

--- a/src/Mafia/Catch.hs
+++ b/src/Mafia/Catch.hs
@@ -1,0 +1,124 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RankNTypes #-}
+module Mafia.Catch (
+    Disaster(..)
+  , bracketF
+  , hushM
+  , bracketEitherT'
+  ) where
+
+import           Control.Monad (return, liftM)
+import           Control.Monad.Catch (catchAll, throwM, handle)
+import           Control.Monad.Catch (Exception(..), SomeException(..))
+import           Control.Monad.Catch (MonadCatch(..), MonadMask(..))
+
+import           Data.Bool (Bool(..))
+import           Data.Either (Either(..), either)
+import           Data.Eq (Eq(..))
+import           Data.Function (($), (.), const, id)
+import           Data.Maybe (Maybe(..))
+import           Data.Ord (Ord(..))
+import           Data.Typeable (typeOf)
+
+import           GHC.Show (appPrec)
+
+import           Mafia.P
+
+import           Text.Show (Show(..), showParen, showString, showChar)
+
+import           Control.Monad.Trans.Either
+
+-- | Newtype wrapper for 'SomeException' which provides an 'Eq' instance which
+--   says no two disasters are equal. It also provides a 'Show' instance
+--   containing only valid Haskell 98 tokens.
+--
+--   This is useful for embedding 'SomeException' in a sensible error type that
+--   has equality for all the other cases.
+newtype Disaster =
+  Disaster {
+      unDisaster :: SomeException
+    }
+
+instance Eq Disaster where
+  (==) _ _ =
+    False
+
+instance Show Disaster where
+  showsPrec prec (Disaster (SomeException e)) =
+    showParen (prec > appPrec) $
+      showString "Disaster " .
+      showsPrec 11 (typeOf e) .
+      showChar ' ' .
+      showsPrec 11 (show e)
+
+data BracketResult a =
+    BracketOk a
+  | BracketFailedFinalizerOk SomeException
+  | BracketFailedFinalizerError a
+
+-- Bracket where you care about the output of the finalizer. If the finalizer fails
+-- with a value level fail, it will return the result of the finalizer.
+-- Finalizer:
+--  - Left indicates a value level fail.
+--  - Right indicates that the finalizer has a value level success, and its results can be ignored.
+--
+bracketF :: MonadMask m => m a -> (a -> m (Either b c)) -> (a -> m b) -> m b
+bracketF a f g =
+  mask $ \restore -> do
+    a' <- a
+    x <- restore (BracketOk `liftM` g a') `catchAll`
+           (\ex -> either BracketFailedFinalizerError (const $ BracketFailedFinalizerOk ex) `liftM` f a')
+    case x of
+      BracketFailedFinalizerOk ex ->
+        throwM ex
+      BracketFailedFinalizerError b ->
+        return b
+      BracketOk b -> do
+        z <- f a'
+        return $ either id (const b) z
+
+-- | Run an action, turning exceptions which pass the predicate in to 'Nothing'
+--   and re-throwing the rest.
+--
+--   Usage:
+--   @
+--   tryOpenFile :: MonadIO m => FilePath -> m (Maybe Handle)
+--   tryOpenFile path =
+--     liftIO . hushM isDoesNotExistError $
+--       openBinaryFile path ReadMode
+--   @
+hushM :: (MonadCatch m, Exception e) => (e -> Bool) -> m a -> m (Maybe a)
+hushM p m =
+  let
+    onError e =
+      if p e then
+        return Nothing
+      else
+        throwM e
+  in
+    handle onError $
+      liftM Just m
+
+-- | Exception and `Left` safe version of bracketEitherT.
+--
+bracketEitherT' :: MonadMask m => EitherT e m a -> (a -> EitherT e m c) -> (a -> EitherT e m b) -> EitherT e m b
+bracketEitherT' acquire release run =
+  EitherT $ bracketF
+    (runEitherT acquire)
+    (\r -> case r of
+      Left _ ->
+        -- Acquire failed, we have nothing to release
+        return . Right $ ()
+      Right r' ->
+        -- Acquire succeeded, we need to try and release
+        runEitherT (release r') >>= \x -> return $ case x of
+          Left err -> Left (Left err)
+          Right _ -> Right ())
+    (\r -> case r of
+      Left err ->
+        -- Acquire failed, we have nothing to run
+        return . Left $ err
+      Right r' ->
+        -- Acquire succeeded, we can do some work
+        runEitherT (run r'))

--- a/src/Mafia/Error.hs
+++ b/src/Mafia/Error.hs
@@ -22,7 +22,7 @@ import           Mafia.Submodule
 
 import           Mafia.P
 
-import           X.Control.Monad.Trans.Either (EitherT)
+import           Control.Monad.Trans.Either (EitherT)
 import           Control.Monad.Trans.Bifunctor (firstT)
 
 -- FIX Leaving this to make code cleanup easier, but ideally is a union of

--- a/src/Mafia/Error.hs
+++ b/src/Mafia/Error.hs
@@ -7,6 +7,9 @@ module Mafia.Error
   , liftCabal
   ) where
 
+import           Control.Monad.Trans.Either (EitherT)
+import           Control.Monad.Trans.Bifunctor (firstT)
+
 import           Mafia.Bin
 import           Mafia.Cabal.Types
 import           Mafia.Cache
@@ -16,14 +19,10 @@ import           Mafia.Hash
 import           Mafia.Init
 import           Mafia.Install
 import           Mafia.Lock
+import           Mafia.P
 import           Mafia.Process
 import           Mafia.Script
 import           Mafia.Submodule
-
-import           Mafia.P
-
-import           Control.Monad.Trans.Either (EitherT)
-import           Control.Monad.Trans.Bifunctor (firstT)
 
 -- FIX Leaving this to make code cleanup easier, but ideally is a union of
 -- sub-exceptions rather than this module being the root of most dependencies
@@ -45,7 +44,6 @@ data MafiaError =
   | MafiaParseError Text
   | MafiaEntryPointNotFound File
   deriving (Show)
-
 
 renderMafiaError :: MafiaError -> Text
 renderMafiaError = \case

--- a/src/Mafia/Error.hs
+++ b/src/Mafia/Error.hs
@@ -20,10 +20,10 @@ import           Mafia.Process
 import           Mafia.Script
 import           Mafia.Submodule
 
-import           P
+import           Mafia.P
 
 import           X.Control.Monad.Trans.Either (EitherT)
-
+import           Control.Monad.Trans.Bifunctor (firstT)
 
 -- FIX Leaving this to make code cleanup easier, but ideally is a union of
 -- sub-exceptions rather than this module being the root of most dependencies

--- a/src/Mafia/Flock.hs
+++ b/src/Mafia/Flock.hs
@@ -17,7 +17,7 @@ import qualified Data.Text as T
 import           Mafia.IO
 import           Mafia.Path
 
-import           P
+import           Mafia.P
 
 import           System.FileLock (SharedExclusive(..), FileLock)
 import qualified System.FileLock as FileLock
@@ -25,7 +25,6 @@ import           System.IO (IO)
 import           System.IO.Unsafe (unsafePerformIO)
 
 import           X.Control.Monad.Trans.Either (EitherT, bracketEitherT')
-
 
 -- | Take a system-wide lock on a file, process safe and thread safe.
 withFileLock :: (MonadIO m, MonadMask m) => File -> EitherT x m () -> EitherT x m a -> EitherT x m a

--- a/src/Mafia/Flock.hs
+++ b/src/Mafia/Flock.hs
@@ -3,12 +3,12 @@ module Mafia.Flock (
     withFileLock
   ) where
 
-import           Control.Monad.Catch (MonadMask(..))
-import           Control.Monad.IO.Class (MonadIO(..))
-
 import           Control.Concurrent.STM (TMVar, newTMVar, tryTakeTMVar, takeTMVar, putTMVar)
 import           Control.Concurrent.STM (TVar, newTVarIO, readTVar, writeTVar)
 import           Control.Concurrent.STM (atomically)
+
+import           Control.Monad.Catch (MonadMask(..))
+import           Control.Monad.Trans.Either (EitherT)
 
 import           Data.Map (Map)
 import qualified Data.Map as Map
@@ -23,8 +23,6 @@ import           System.FileLock (SharedExclusive(..), FileLock)
 import qualified System.FileLock as FileLock
 import           System.IO (IO)
 import           System.IO.Unsafe (unsafePerformIO)
-
-import           Control.Monad.Trans.Either
 
 -- | Take a system-wide lock on a file, process safe and thread safe.
 withFileLock :: (MonadIO m, MonadMask m) => File -> EitherT x m () -> EitherT x m a -> EitherT x m a

--- a/src/Mafia/Flock.hs
+++ b/src/Mafia/Flock.hs
@@ -14,17 +14,17 @@ import           Data.Map (Map)
 import qualified Data.Map as Map
 import qualified Data.Text as T
 
+import           Mafia.Catch
 import           Mafia.IO
-import           Mafia.Path
-
 import           Mafia.P
+import           Mafia.Path
 
 import           System.FileLock (SharedExclusive(..), FileLock)
 import qualified System.FileLock as FileLock
 import           System.IO (IO)
 import           System.IO.Unsafe (unsafePerformIO)
 
-import           X.Control.Monad.Trans.Either (EitherT, bracketEitherT')
+import           Control.Monad.Trans.Either
 
 -- | Take a system-wide lock on a file, process safe and thread safe.
 withFileLock :: (MonadIO m, MonadMask m) => File -> EitherT x m () -> EitherT x m a -> EitherT x m a

--- a/src/Mafia/Ghc.hs
+++ b/src/Mafia/Ghc.hs
@@ -14,17 +14,15 @@ module Mafia.Ghc (
   , renderGhcError
   ) where
 
+import           Control.Monad.Trans.Either (EitherT, left, runEitherT)
+
 import qualified Data.Text as T
 
+import           Mafia.P
 import           Mafia.Package
 import           Mafia.Process
 
-import           Mafia.P
-
 import           System.IO (IO)
-
-import           Control.Monad.Trans.Either (EitherT, left, runEitherT)
-
 
 newtype GhcVersion =
   GhcVersion {

--- a/src/Mafia/Ghc.hs
+++ b/src/Mafia/Ghc.hs
@@ -19,7 +19,7 @@ import qualified Data.Text as T
 import           Mafia.Package
 import           Mafia.Process
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 

--- a/src/Mafia/Ghc.hs
+++ b/src/Mafia/Ghc.hs
@@ -23,7 +23,7 @@ import           Mafia.P
 
 import           System.IO (IO)
 
-import           X.Control.Monad.Trans.Either (EitherT, left, runEitherT)
+import           Control.Monad.Trans.Either (EitherT, left, runEitherT)
 
 
 newtype GhcVersion =

--- a/src/Mafia/Git.hs
+++ b/src/Mafia/Git.hs
@@ -21,7 +21,7 @@ import qualified Data.Text.IO as T
 import           Mafia.Path
 import           Mafia.Process
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO, stderr)
 

--- a/src/Mafia/Git.hs
+++ b/src/Mafia/Git.hs
@@ -25,7 +25,7 @@ import           Mafia.P
 
 import           System.IO (IO, stderr)
 
-import           X.Control.Monad.Trans.Either (EitherT, left)
+import           Control.Monad.Trans.Either (EitherT, left)
 
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Git.hs
+++ b/src/Mafia/Git.hs
@@ -13,7 +13,7 @@ module Mafia.Git
     , getSubmodules
     ) where
 
-import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Trans.Either (EitherT, left)
 
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
@@ -25,7 +25,6 @@ import           Mafia.P
 
 import           System.IO (IO, stderr)
 
-import           Control.Monad.Trans.Either (EitherT, left)
 
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Hash.hs
+++ b/src/Mafia/Hash.hs
@@ -18,6 +18,8 @@ module Mafia.Hash
   , tryHashFile
   ) where
 
+import           Control.Monad.Trans.Either (EitherT, left)
+
 import           Crypto.Hash (Digest, SHA1)
 import qualified Crypto.Hash as Hash
 
@@ -31,13 +33,10 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 
 import           Mafia.IO
+import           Mafia.P
 import           Mafia.Path
 
-import           Mafia.P
-
 import           System.IO (IO)
-
-import           Control.Monad.Trans.Either (EitherT, left)
 
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Hash.hs
+++ b/src/Mafia/Hash.hs
@@ -33,7 +33,7 @@ import qualified Data.Text.Encoding as T
 import           Mafia.IO
 import           Mafia.Path
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 

--- a/src/Mafia/Hash.hs
+++ b/src/Mafia/Hash.hs
@@ -37,7 +37,7 @@ import           Mafia.P
 
 import           System.IO (IO)
 
-import           X.Control.Monad.Trans.Either (EitherT, left)
+import           Control.Monad.Trans.Either (EitherT, left)
 
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Home.hs
+++ b/src/Mafia/Home.hs
@@ -15,8 +15,7 @@ import qualified Data.Text as T
 import           Mafia.IO
 import           Mafia.Path
 
-import           P
-
+import           Mafia.P
 
 getMafiaHome :: MonadIO m => m Directory
 getMafiaHome = do

--- a/src/Mafia/Home.hs
+++ b/src/Mafia/Home.hs
@@ -8,14 +8,11 @@ module Mafia.Home
   , ensureMafiaDir
   ) where
 
-import           Control.Monad.IO.Class (MonadIO(..))
-
 import qualified Data.Text as T
 
 import           Mafia.IO
-import           Mafia.Path
-
 import           Mafia.P
+import           Mafia.Path
 
 getMafiaHome :: MonadIO m => m Directory
 getMafiaHome = do

--- a/src/Mafia/Hoogle.hs
+++ b/src/Mafia/Hoogle.hs
@@ -31,7 +31,7 @@ import           Mafia.P
 
 import           System.IO (IO, stderr)
 
-import           X.Control.Monad.Trans.Either (EitherT, hoistEither, runEitherT)
+import           Control.Monad.Trans.Either (EitherT, hoistEither, runEitherT)
 import           Control.Monad.Trans.Bifunctor (firstT, bimapT)
 
 newtype HooglePackagesSandbox = HooglePackagesSandbox [PackageId]

--- a/src/Mafia/Hoogle.hs
+++ b/src/Mafia/Hoogle.hs
@@ -27,12 +27,12 @@ import           Mafia.Package
 import           Mafia.Path
 import           Mafia.Process
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO, stderr)
 
 import           X.Control.Monad.Trans.Either (EitherT, hoistEither, runEitherT)
-
+import           Control.Monad.Trans.Bifunctor (firstT, bimapT)
 
 newtype HooglePackagesSandbox = HooglePackagesSandbox [PackageId]
 newtype HooglePackagesCached = HooglePackagesCached [PackageId]

--- a/src/Mafia/Hoogle.hs
+++ b/src/Mafia/Hoogle.hs
@@ -8,7 +8,8 @@ module Mafia.Hoogle
   , joinHooglePackages
   ) where
 
-import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Trans.Bifunctor (firstT, bimapT)
+import           Control.Monad.Trans.Either (EitherT, hoistEither, runEitherT)
 
 import qualified Data.List as L
 import           Data.Map (Map)
@@ -26,13 +27,9 @@ import           Mafia.Init
 import           Mafia.Package
 import           Mafia.Path
 import           Mafia.Process
-
 import           Mafia.P
 
 import           System.IO (IO, stderr)
-
-import           Control.Monad.Trans.Either (EitherT, hoistEither, runEitherT)
-import           Control.Monad.Trans.Bifunctor (firstT, bimapT)
 
 newtype HooglePackagesSandbox = HooglePackagesSandbox [PackageId]
 newtype HooglePackagesCached = HooglePackagesCached [PackageId]

--- a/src/Mafia/IO.hs
+++ b/src/Mafia/IO.hs
@@ -72,7 +72,7 @@ import           Data.Time (UTCTime)
 
 import           Mafia.Path
 
-import           P
+import           Mafia.P
 
 import qualified System.Directory as Directory
 import qualified System.Environment as Environment

--- a/src/Mafia/IO.hs
+++ b/src/Mafia/IO.hs
@@ -81,8 +81,8 @@ import           System.IO.Error (isDoesNotExistError)
 import qualified System.IO.Temp as Temp
 import qualified System.Posix.Files as Posix
 
-import           X.Control.Monad.Trans.Either (EitherT, pattern EitherT)
-import           X.Control.Monad.Trans.Either (runEitherT, hoistEither)
+import           Control.Monad.Trans.Either (EitherT, pattern EitherT)
+import           Control.Monad.Trans.Either (runEitherT, hoistEither)
 
 ------------------------------------------------------------------------
 -- Directory Operations

--- a/src/Mafia/IO.hs
+++ b/src/Mafia/IO.hs
@@ -59,7 +59,8 @@ module Mafia.IO
 import qualified Control.Concurrent.Async as Async
 import           Control.Exception (IOException)
 import           Control.Monad.Catch (MonadMask(..), MonadCatch(..), handle, throwM)
-import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Trans.Either (EitherT, pattern EitherT)
+import           Control.Monad.Trans.Either (runEitherT, hoistEither)
 import           Control.Monad.Trans.Maybe (MaybeT(..))
 
 import           Data.ByteString (ByteString)
@@ -70,9 +71,8 @@ import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import           Data.Time (UTCTime)
 
-import           Mafia.Path
-
 import           Mafia.P
+import           Mafia.Path
 
 import qualified System.Directory as Directory
 import qualified System.Environment as Environment
@@ -80,9 +80,6 @@ import           System.IO (IO)
 import           System.IO.Error (isDoesNotExistError)
 import qualified System.IO.Temp as Temp
 import qualified System.Posix.Files as Posix
-
-import           Control.Monad.Trans.Either (EitherT, pattern EitherT)
-import           Control.Monad.Trans.Either (runEitherT, hoistEither)
 
 ------------------------------------------------------------------------
 -- Directory Operations

--- a/src/Mafia/Include.hs
+++ b/src/Mafia/Include.hs
@@ -16,7 +16,7 @@ import           Mafia.P
 
 import           System.IO (IO)
 
-import           Control.Monad.Trans.Bifunctor
+import           Control.Monad.Trans.Bifunctor (firstT)
 import           Control.Monad.Trans.Either (EitherT)
 
 getIncludeDirs :: EitherT MafiaError IO [Path]

--- a/src/Mafia/Include.hs
+++ b/src/Mafia/Include.hs
@@ -12,11 +12,12 @@ import           Mafia.IO
 import           Mafia.Path
 import           Mafia.Error
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 
-import           X.Control.Monad.Trans.Either (EitherT)
+import           Control.Monad.Trans.Bifunctor
+import           Control.Monad.Trans.Either (EitherT)
 
 getIncludeDirs :: EitherT MafiaError IO [Path]
 getIncludeDirs = do
@@ -40,4 +41,3 @@ parseLine line
  = is
  | otherwise
  = []
-

--- a/src/Mafia/Init.hs
+++ b/src/Mafia/Init.hs
@@ -39,11 +39,12 @@ import           Mafia.Path
 import           Mafia.Process
 import           Mafia.Submodule
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO, stderr)
 
-import           X.Control.Monad.Trans.Either (EitherT, runEitherT, hoistEither)
+import           Control.Monad.Trans.Bifunctor
+import           Control.Monad.Trans.Either (EitherT, runEitherT, hoistEither)
 
 
 data InitError =

--- a/src/Mafia/Init.hs
+++ b/src/Mafia/Init.hs
@@ -17,7 +17,8 @@ module Mafia.Init (
   , renderInitError
   ) where
 
-import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Trans.Bifunctor (firstT)
+import           Control.Monad.Trans.Either (EitherT, runEitherT, hoistEither)
 
 import           Data.Aeson (Value(..), ToJSON(..), FromJSON(..), (.:), (.=))
 import qualified Data.Aeson as A
@@ -35,17 +36,12 @@ import           Mafia.Hash
 import           Mafia.IO
 import           Mafia.Install
 import           Mafia.Lock
+import           Mafia.P
 import           Mafia.Path
 import           Mafia.Process
 import           Mafia.Submodule
 
-import           Mafia.P
-
 import           System.IO (IO, stderr)
-
-import           Control.Monad.Trans.Bifunctor
-import           Control.Monad.Trans.Either (EitherT, runEitherT, hoistEither)
-
 
 data InitError =
     InitHashError HashError

--- a/src/Mafia/Install.hs
+++ b/src/Mafia/Install.hs
@@ -43,15 +43,13 @@ import           Mafia.Package
 import           Mafia.Path
 import           Mafia.Process
 import           Mafia.Tree
+import           Mafia.Twine
 
 import           Numeric (showHex)
 
 import           P
 
 import           System.IO (IO, stderr)
-
-import           Twine.Parallel (RunError(..), consume_)
-import           Twine.Data.Queue  (writeQueue)
 
 import           X.Control.Monad.Trans.Either
 

--- a/src/Mafia/Install.hs
+++ b/src/Mafia/Install.hs
@@ -47,11 +47,12 @@ import           Mafia.Twine
 
 import           Numeric (showHex)
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO, stderr)
 
-import           X.Control.Monad.Trans.Either
+import           Control.Monad.Trans.Either
+import           Control.Monad.Trans.Bifunctor
 
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Install.hs
+++ b/src/Mafia/Install.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE PatternSynonyms #-}
 module Mafia.Install
   ( Flavour(..)
   , installDependencies
@@ -13,7 +14,8 @@ module Mafia.Install
   ) where
 
 import           Control.Exception (SomeException)
-import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Trans.Bifunctor (firstT)
+import           Control.Monad.Trans.Either (EitherT, pattern EitherT, left, runEitherT)
 import           Control.Parallel.Strategies (rpar, parMap)
 import qualified Control.Retry as Retry
 
@@ -39,6 +41,7 @@ import           Mafia.Cabal.Sandbox
 import           Mafia.Cabal.Types
 import           Mafia.Cache
 import           Mafia.IO
+import           Mafia.P
 import           Mafia.Package
 import           Mafia.Path
 import           Mafia.Process
@@ -47,12 +50,7 @@ import           Mafia.Twine
 
 import           Numeric (showHex)
 
-import           Mafia.P
-
 import           System.IO (IO, stderr)
-
-import           Control.Monad.Trans.Either
-import           Control.Monad.Trans.Bifunctor
 
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Lock.hs
+++ b/src/Mafia/Lock.hs
@@ -18,12 +18,12 @@ import           Mafia.Ghc
 import           Mafia.IO
 import           Mafia.Path
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 
-import           X.Control.Monad.Trans.Either (EitherT, hoistEither, left)
-
+import           Control.Monad.Trans.Bifunctor
+import           Control.Monad.Trans.Either (EitherT, hoistEither, left)
 
 data LockError =
     LockCabalError CabalError

--- a/src/Mafia/Lock.hs
+++ b/src/Mafia/Lock.hs
@@ -11,6 +11,9 @@ module Mafia.Lock (
   , writeLockFile
   ) where
 
+import           Control.Monad.Trans.Bifunctor (firstT)
+import           Control.Monad.Trans.Either (EitherT, hoistEither, left)
+
 import qualified Data.Text as T
 
 import           Mafia.Cabal
@@ -21,9 +24,6 @@ import           Mafia.Path
 import           Mafia.P
 
 import           System.IO (IO)
-
-import           Control.Monad.Trans.Bifunctor
-import           Control.Monad.Trans.Either (EitherT, hoistEither, left)
 
 data LockError =
     LockCabalError CabalError

--- a/src/Mafia/Makefile.hs
+++ b/src/Mafia/Makefile.hs
@@ -4,6 +4,9 @@ module Mafia.Makefile
   ( buildMakefile
   ) where
 
+import           Control.Monad.Trans.Bifunctor (firstT)
+import           Control.Monad.Trans.Either (EitherT)
+
 import qualified Data.Map as Map
 
 import           Mafia.Cabal
@@ -15,9 +18,6 @@ import           Mafia.Error
 import           Mafia.P
 
 import           System.IO (IO)
-
-import           Control.Monad.Trans.Bifunctor
-import           Control.Monad.Trans.Either (EitherT)
 
 buildMakefile :: Directory -> EitherT MafiaError IO ()
 buildMakefile directory = do

--- a/src/Mafia/Makefile.hs
+++ b/src/Mafia/Makefile.hs
@@ -12,11 +12,12 @@ import           Mafia.Path
 import           Mafia.Process
 import           Mafia.Error
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 
-import           X.Control.Monad.Trans.Either (EitherT)
+import           Control.Monad.Trans.Bifunctor
+import           Control.Monad.Trans.Either (EitherT)
 
 buildMakefile :: Directory -> EitherT MafiaError IO ()
 buildMakefile directory = do
@@ -37,4 +38,3 @@ callMakefile makeFile = do
          , processDirectory   = Nothing
          , processEnvironment = Just (Map.insert "MAFIA" mafia env) }
   return ()
-

--- a/src/Mafia/Options/Applicative.hs
+++ b/src/Mafia/Options/Applicative.hs
@@ -20,6 +20,8 @@ module Mafia.Options.Applicative (
   , orDieWithCode
   ) where
 
+import           Control.Monad.Trans.Either (EitherT, runEitherT)
+
 import qualified Data.Attoparsec.Text as A
 import           Data.String (String)
 import qualified Data.Text as T
@@ -29,11 +31,9 @@ import           Options.Applicative.Types as X
 
 import           Mafia.P
 
-import           System.IO (IO, putStrLn, print, hPutStrLn, stderr)
 import           System.Environment (getArgs)
 import           System.Exit (exitSuccess, ExitCode(..), exitWith)
-
-import           Control.Monad.Trans.Either
+import           System.IO (IO, putStrLn, print, hPutStrLn, stderr)
 
 data RunType =
     DryRun

--- a/src/Mafia/Options/Applicative.hs
+++ b/src/Mafia/Options/Applicative.hs
@@ -1,0 +1,167 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Mafia.Options.Applicative (
+    module X
+  , RunType (..)
+  , SafeCommand (..)
+  , maybeTextReader
+  , eitherTextReader
+  , pOption
+  , textRead
+  , command'
+  , dispatch
+  , cli
+  , daemon
+  , safeCommand
+  , versionFlag
+  , dryRunFlag
+
+  , orDie
+  , orDieWithCode
+  ) where
+
+import qualified Data.Attoparsec.Text as A
+import           Data.String (String)
+import qualified Data.Text as T
+
+import           Options.Applicative as X
+import           Options.Applicative.Types as X
+
+import           Mafia.P
+
+import           System.IO (IO, putStrLn, print, hPutStrLn, stderr)
+import           System.Environment (getArgs)
+import           System.Exit (exitSuccess, ExitCode(..), exitWith)
+
+import           Control.Monad.Trans.Either
+
+data RunType =
+    DryRun
+  | RealRun
+  deriving (Eq, Show)
+
+data SafeCommand a =
+    VersionCommand
+  | DependencyCommand
+  | RunCommand RunType a
+  deriving (Eq, Show)
+
+-- | Turn a parser into a ReadM
+maybeTextReader :: (Text -> Maybe a) -> ReadM a
+maybeTextReader f =
+  eitherReader $ \s ->
+    maybe (Left $ "Failed to parse: " <> s) pure . f . T.pack $ s
+
+-- | Turn a parser into a ReadM
+eitherTextReader :: (e -> Text) -> (Text -> Either e a) -> ReadM a
+eitherTextReader render f =
+  eitherReader $
+    either (Left . T.unpack . render) Right . f . T.pack
+
+-- | Turn apn attoparsec parser into a ReadM
+pOption :: A.Parser a -> ReadM a
+pOption p =
+  eitherReader (A.parseOnly p . T.pack)
+
+textRead :: ReadM Text
+textRead = fmap T.pack str
+
+-- | A 'command' combinator that adds helper and description in a
+--   slightly cleaner way
+command' :: String -> String -> Parser a -> Mod CommandFields a
+command' label description parser =
+  command label (info (parser <**> helper) (progDesc description))
+
+-- | Dispatch multi-mode programs with appropriate helper to make the
+--   default behaviour a bit better.
+dispatch :: Parser a -> IO a
+dispatch p = getArgs >>= \x -> case x of
+  [] -> let -- We don't need to see the Missing error if we're getting the whole usage string.
+            removeError' (h, e, c) = (h { helpError = mempty }, e, c)
+            removeError (Failure (ParserFailure failure)) = Failure (ParserFailure ( removeError' <$> failure ))
+            removeError a = a
+        in  execParserPure (prefs showHelpOnError) (info (p <**> helper) idm) <$> getArgs
+            >>= handleParseResult . removeError
+  _  -> execParser (info (p <**> helper) idm)
+
+-- | Simple interface over 'dispatch' and 'safeCommand'
+--
+-- @ name -> version -> dependencyInfo -> parser -> action @
+--
+--   Example usage:
+--
+-- > cli "my-cli" buildInfoVersion dependencyInfo myThingParser $ \c ->
+-- >  case c of
+-- >      DoThingA -> ...
+-- >      DoThingB -> ...
+cli :: Show a => [Char] -> [Char] -> [[Char]] -> Parser a -> (a -> IO b) -> IO b
+cli name v deps commandParser act = do
+  dispatch (safeCommand commandParser) >>= \a ->
+    case a of
+      VersionCommand ->
+        putStrLn (name <> ": " <> v) >> exitSuccess
+      DependencyCommand ->
+        mapM putStrLn deps >> exitSuccess
+      RunCommand DryRun c ->
+        print c >> exitSuccess
+      RunCommand RealRun c ->
+        act c
+
+-- | Simple interface over 'dispatch' with default parsers for help,
+-- 'VersionCommand', 'DependencyCommand' and 'RunCommand'.
+--
+-- @ name -> version -> dependencyInfo -> action @
+--
+--   Example usage:
+--
+-- > daemon "my-daemon" buildInfoVersion dependencyInfo $ do
+-- >  loop my-loop
+daemon :: [Char] -> [Char] -> [[Char]] -> IO a -> IO a
+daemon name v deps act =
+  cli name v deps (pure ()) $ \() ->
+    act
+
+-- | Turn a Parser for a command of type a into a safe command
+--   with a dry-run mode and a version flag
+safeCommand :: Parser a -> Parser (SafeCommand a)
+safeCommand commandParser =
+      VersionCommand <$ versionFlag
+  <|> DependencyCommand <$ dependencyFlag
+  <|> RunCommand <$> dryRunFlag <*> commandParser
+
+versionFlag :: Parser ()
+versionFlag =
+  flag' () $
+       short 'v'
+    <> long "version"
+    <> help "Version information"
+
+dependencyFlag :: Parser ()
+dependencyFlag =
+  flag' () $
+       long "dependencies"
+    <> hidden
+
+dryRunFlag :: Parser RunType
+dryRunFlag =
+  flag RealRun DryRun $
+       long "dry-run"
+    <> hidden
+
+-- | orDieWithCode with an exit code of 1 in case of an error
+--
+orDie :: (e -> Text) -> EitherT e IO a -> IO a
+orDie = orDieWithCode 1
+
+-- | An idiom for failing hard on EitherT errors.
+--
+-- *This really dies*. There is no other way to say it.
+--
+-- The reason it lives with command line parser tooling, is that is
+-- the only valid place to actually exit like this. Be appropriately
+-- wary.
+--
+orDieWithCode :: Int -> (e -> Text) -> EitherT e IO a -> IO a
+orDieWithCode code render e =
+  runEitherT e >>=
+    either (\err -> (hPutStrLn stderr . T.unpack . render) err >> exitWith (ExitFailure code)) pure

--- a/src/Mafia/P.hs
+++ b/src/Mafia/P.hs
@@ -1,0 +1,394 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+module Mafia.P (
+  -- * Primitive types
+  -- ** Bool
+    Bool (..)
+  , bool
+  , (&&)
+  , (||)
+  , not
+  , otherwise
+  -- ** Char
+  , Char
+  -- ** Int
+  , Integer
+  , Int
+  , Int8
+  , Int16
+  , Int32
+  , Int64
+  , div
+  -- ** Word
+  , Word64
+  -- ** Real
+  , fromIntegral
+  , fromRational
+
+  , Double
+
+  -- * Algebraic structures
+  -- ** Monoid
+  , Monoid (..)
+  , (<>)
+  -- ** Functor
+  , Functor (..)
+  , (<$>)
+  , ($>)
+  , void
+  , with
+  -- ** Bifunctor
+  , Bifunctor (..)
+  -- ** Applicative
+  , Applicative (..)
+  , (<**>)
+  , orA
+  , andA
+  , optional
+  -- ** Alternative
+  , Alternative (..)
+  , asum
+  -- ** Monad
+  , Monad (..)
+  , join
+  , bind
+  , when
+  , unless
+  , mapM_
+  , forever
+  , unlessM
+  , whenM
+  , ifM
+  , guardM
+  , filterM
+  , (=<<)
+  , liftM
+  -- ** MonadPlus
+  , MonadPlus (..)
+  , guard
+  , msum
+  -- ** MonadIO
+  , MonadIO (..)
+
+  -- * Data structures
+  -- ** Either
+  , Either (..)
+  , either
+  -- ** Maybe
+  , Maybe (..)
+  , fromMaybe
+  , maybe
+  , isJust
+  , mapMaybe
+  , maybeToRight
+  , catMaybes
+  -- ** Tuple
+  , fst
+  , snd
+  , curry
+  , uncurry
+  -- ** List
+  , module List
+  -- * Typeclasses
+  -- ** Enum
+  , Enum
+  -- ** Num
+  , Num (..)
+  -- ** Eq
+  , Eq (..)
+  -- ** Read
+  , Read (..)
+  , readEither
+  , readMaybe
+  -- ** Show
+  , Show (..)
+  -- *** ShowS
+  , ShowS
+  , showString
+  -- ** Foldable
+  , Foldable (..)
+  , for_
+  , forM_
+  , all
+  , head
+  , concat
+  , concatMap
+  -- ** Ord
+  , Ord (..)
+  , Ordering (..)
+  , comparing
+  -- ** Traversable
+  , Traversable (..)
+  , for
+  , forM
+  , traverse_
+
+  -- * Combinators
+  , id
+  , (.)
+  , ($)
+  , ($!)
+  , (&)
+  , const
+  , flip
+  , fix
+  , on
+  , seq
+
+  -- * Text functions
+  , Text
+  -- * Partial functions
+  , undefined
+  , error
+
+  -- * Debugging facilities
+  , trace
+  , traceM
+  , traceIO
+  ) where
+
+
+import           Control.Monad as Monad (
+           Monad (..)
+         , MonadPlus (..)
+         , guard
+         , join
+         , msum
+         , when
+         , unless
+         , guard
+         , mapM_
+         , forever
+         , (=<<)
+         , filterM
+         , liftM
+         )
+import           Control.Monad.IO.Class (
+           MonadIO (..)
+         )
+import           Control.Applicative as Applicative (
+           Applicative (..)
+         , (<**>)
+         , Alternative (..)
+         , empty
+         , liftA2
+         , optional
+         )
+
+import           Data.Bifunctor as Bifunctor (
+           Bifunctor (..)
+         )
+import           Data.Bool as Bool (
+           Bool (..)
+         , bool
+         , (&&)
+         , (||)
+         , not
+         , otherwise
+         )
+import           Data.Char as Char (
+           Char
+         )
+import           Data.Either as Either (
+           Either (..)
+         , either
+         )
+import           Data.Foldable as Foldable (
+           Foldable (..)
+         , asum
+         , traverse_
+         , for_
+         , forM_
+         , all
+         , concat
+         , concatMap
+         )
+import           Data.Function as Function (
+           id
+         , (.)
+         , ($)
+         , (&)
+         , const
+         , flip
+         , fix
+         , on
+         )
+import           Data.Functor as Functor (
+           Functor (..)
+         , (<$>)
+         , ($>)
+         , void
+         )
+import           Data.Eq as Eq (
+           Eq (..)
+         )
+import           Data.Int as Int (
+           Int
+         , Int8
+         , Int16
+         , Int32
+         , Int64
+         )
+import           Data.Maybe as Maybe (
+           Maybe (..)
+         , fromMaybe
+         , maybe
+         , isJust
+         , mapMaybe
+         , catMaybes
+         )
+import           Data.Monoid as Monoid (
+           Monoid (..)
+         , (<>)
+         )
+import           Data.Ord as Ord (
+           Ord (..)
+         , Ordering (..)
+         , comparing
+         )
+import           Data.Traversable as Traversable (
+           Traversable (..)
+         , for
+         , forM
+         , mapM
+         )
+import           Data.Tuple as Tuple (
+           fst
+         , snd
+         , curry
+         , uncurry
+         )
+import           Data.Word as Word (
+           Word64
+         )
+import           Data.List as List (
+                     intercalate
+                   , isPrefixOf
+                   , drop
+                   , splitAt
+                   , break
+                   , filter
+                   , reverse
+                   , any
+#if (__GLASGOW_HASKELL__ < 710)
+                   , length
+                   , null
+#endif
+                   )
+import qualified Debug.Trace as Trace
+import           GHC.Types as Types (
+           Double
+         )
+import           GHC.Real as Real (
+           fromIntegral
+         , fromRational
+         , div
+         )
+#if MIN_VERSION_base(4,9,0)
+import           GHC.Stack (HasCallStack)
+#endif
+
+import           Prelude as Prelude (
+           Enum
+         , Num (..)
+         , Integer
+         , seq
+         , ($!)
+         )
+import qualified Prelude as Unsafe
+
+import           System.IO as IO (
+           IO
+         )
+import           Data.Text as Text (Text)
+import           Text.Read as Read (
+           Read (..)
+         , readEither
+         , readMaybe
+         )
+import           Text.Show as Show (
+           Show (..)
+         , ShowS
+         , showString
+         )
+
+#if MIN_VERSION_base(4,9,0)
+undefined :: HasCallStack => a
+#else
+undefined :: a
+#endif
+undefined =
+  Unsafe.undefined
+{-# WARNING undefined "'undefined' is unsafe" #-}
+
+#if MIN_VERSION_base(4,9,0)
+error :: HasCallStack => [Char] -> a
+#else
+error :: [Char] -> a
+#endif
+error =
+  Unsafe.error
+{-# WARNING error "'error' is unsafe" #-}
+
+trace :: [Char] -> a -> a
+trace =
+  Trace.trace
+{-# WARNING trace "'trace' should only be used while debugging" #-}
+
+#if MIN_VERSION_base(4,9,0)
+traceM :: Applicative f => [Char] -> f ()
+#else
+traceM :: Monad m => [Char] -> m ()
+#endif
+traceM =
+  Trace.traceM
+{-# WARNING traceM "'traceM' should only be used while debugging" #-}
+
+traceIO :: [Char] -> IO ()
+traceIO =
+  Trace.traceIO
+{-# WARNING traceIO "'traceIO' should only be used while debugging" #-}
+
+with :: Functor f => f a -> (a -> b) -> f b
+with =
+  flip fmap
+{-# INLINE with #-}
+
+whenM :: Monad m => m Bool -> m () -> m ()
+whenM p m =
+  p >>= flip when m
+
+unlessM :: Monad m => m Bool -> m () -> m ()
+unlessM p m =
+  p >>= flip unless m
+
+ifM :: Monad m => m Bool -> m a -> m a -> m a
+ifM p x y =
+  p >>= \b -> if b then x else y
+
+guardM :: MonadPlus m => m Bool -> m ()
+guardM f = guard =<< f
+
+-- | Identifier version of 'Control.Monad.=<<'.
+bind :: Monad m => (a -> m b) -> m a -> m b
+bind = (=<<)
+
+head :: (Foldable f) => f a -> Maybe a
+head = foldr (\x _ -> return x) Nothing
+
+-- | Logical disjunction.
+orA :: Applicative f => f Bool -> f Bool -> f Bool
+orA =
+  liftA2 (||)
+
+-- | Logical conjunction.
+andA :: Applicative f => f Bool -> f Bool -> f Bool
+andA =
+  liftA2 (&&)
+
+infixl 8 `andA`, `orA`
+
+maybeToRight :: l -> Maybe r -> Either l r
+maybeToRight l = maybe (Left l) Right

--- a/src/Mafia/P.hs
+++ b/src/Mafia/P.hs
@@ -81,9 +81,12 @@ module Mafia.P (
   , fromMaybe
   , maybe
   , isJust
+  , isNothing
   , mapMaybe
   , maybeToRight
   , catMaybes
+  , listToMaybe
+  , rightToMaybe
   -- ** Tuple
   , fst
   , snd
@@ -236,8 +239,10 @@ import           Data.Maybe as Maybe (
          , fromMaybe
          , maybe
          , isJust
+         , isNothing
          , mapMaybe
          , catMaybes
+         , listToMaybe
          )
 import           Data.Monoid as Monoid (
            Monoid (..)
@@ -272,6 +277,8 @@ import           Data.List as List (
                    , filter
                    , reverse
                    , any
+                   , and
+                   , notElem
 #if (__GLASGOW_HASKELL__ < 710)
                    , length
                    , null
@@ -392,3 +399,6 @@ infixl 8 `andA`, `orA`
 
 maybeToRight :: l -> Maybe r -> Either l r
 maybeToRight l = maybe (Left l) Right
+
+rightToMaybe :: Either l r -> Maybe r
+rightToMaybe = either (const Nothing) Just

--- a/src/Mafia/P.hs
+++ b/src/Mafia/P.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE LambdaCase #-}
 module Mafia.P (
   -- * Primitive types
   -- ** Bool
@@ -94,6 +95,8 @@ module Mafia.P (
   , uncurry
   -- ** List
   , module List
+  , ordNub
+  , ordNubBy
   -- * Typeclasses
   -- ** Enum
   , Enum
@@ -320,6 +323,7 @@ import           Text.Show as Show (
          , ShowS
          , showString
          )
+import qualified Data.Set as Set
 
 #if MIN_VERSION_base(4,9,0)
 undefined :: HasCallStack => a
@@ -402,3 +406,58 @@ maybeToRight l = maybe (Left l) Right
 
 rightToMaybe :: Either l r -> Maybe r
 rightToMaybe = either (const Nothing) Just
+
+-- | /O(n log n)/ Remove duplicate elements from a list.
+--
+--   Unlike 'Data.List.nub', this version requires 'Ord' and runs in
+--   /O(n log n)/ instead of /O(n²)/. Like 'Data.List.nub' the output
+--   order is identical to the input order.
+--   See 'sortNub' for `nub` behaviour with sorted output.
+--
+--   > ordNub "foo bar baz" == "fo barz"
+--   > ordNub [3,2,1,2,1] == [3,2,1]
+--   > List.take 3 (ordNub [4,5,6,undefined]) == [4,5,6]
+--   > ordNub xs == List.nub xs
+--
+ordNub :: Ord a => [a] -> [a]
+ordNub =
+  ordNubBy compare
+
+-- | /O(n log n)/ Behaves exactly like 'ordNub' except it uses a user-supplied
+--  comparison function.
+--
+--  > ordNubBy (comparing length) ["foo","bar","quux"] == ["foo","quux"]
+--  > ordNubBy (comparing fst) [("foo", 10),("foo", 20),("bar", 30)] == [("foo", 10),("bar", 30)]
+--
+ordNubBy :: (a -> a -> Ordering) -> [a] -> [a]
+ordNubBy f =
+  let
+    loop seen = \case
+      [] ->
+        []
+      x : xs ->
+        let
+          y =
+            UserOrd f x
+        in
+          if Set.member y seen then
+            loop seen xs
+          else
+            x : loop (Set.insert y seen) xs
+   in
+     loop Set.empty
+
+--
+-- Some machinery so we can use Data.Set with a custom comparator.
+--
+
+data UserOrd a =
+  UserOrd (a -> a -> Ordering) a
+
+instance Eq (UserOrd a) where
+  (==) (UserOrd f x) (UserOrd _ y) =
+    f x y == EQ
+
+instance Ord (UserOrd a) where
+  compare (UserOrd f x) (UserOrd _ y) =
+    f x y

--- a/src/Mafia/Package.hs
+++ b/src/Mafia/Package.hs
@@ -28,7 +28,7 @@ import qualified Data.Text as T
 import           Distribution.Version (Version, versionNumbers)
 import qualified Distribution.Version as DistVersion
 
-import           P
+import           Mafia.P
 
 import qualified Data.Attoparsec.Text as Parse
 

--- a/src/Mafia/Path.hs
+++ b/src/Mafia/Path.hs
@@ -25,7 +25,7 @@ module Mafia.Path
 import qualified Data.List as List
 import qualified Data.Text as T
 
-import           P
+import           Mafia.P
 
 import qualified System.FilePath as FilePath
 

--- a/src/Mafia/Process.hs
+++ b/src/Mafia/Process.hs
@@ -49,7 +49,7 @@ module Mafia.Process
 import           Control.Concurrent.Async (Async, async, waitCatch)
 import           Control.Exception (SomeException, IOException, toException)
 import           Control.Monad.Catch (MonadCatch(..), handle, bracket_)
-import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Trans.Either (EitherT, firstEitherT, left, hoistEither, newEitherT)
 
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as B
@@ -61,7 +61,6 @@ import qualified Data.Text.Encoding as T
 
 import           Mafia.Path (File, Directory)
 import           Mafia.IO (setCurrentDirectory)
-
 import           Mafia.P
 
 import           System.Exit (ExitCode(..))
@@ -69,11 +68,9 @@ import           System.IO (IO, FilePath, Handle, BufferMode(..))
 import qualified System.IO as IO
 import qualified System.Process as Process
 import qualified System.Process.Internals as ProcessInternals
-import qualified System.Posix.Types   as Posix
+import qualified System.Posix.Types as Posix
 import qualified System.Posix.Process as Posix
 import qualified System.Posix.Signals as Signals
-
-import           Control.Monad.Trans.Either
 
 ------------------------------------------------------------------------
 
@@ -502,7 +499,7 @@ handleIO p =
   in handle (hoistEither . Left . ProcessException p . fromIO)
 
 waitCatchE :: (Functor m, MonadIO m) => Process -> Async a -> EitherT ProcessError m a
-waitCatchE p = firstEitherT (ProcessException p) . EitherT . liftIO . waitCatch
+waitCatchE p = firstEitherT (ProcessException p) . newEitherT . liftIO . waitCatch
 
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Process.hs
+++ b/src/Mafia/Process.hs
@@ -62,7 +62,7 @@ import qualified Data.Text.Encoding as T
 import           Mafia.Path (File, Directory)
 import           Mafia.IO (setCurrentDirectory)
 
-import           P
+import           Mafia.P
 
 import           System.Exit (ExitCode(..))
 import           System.IO (IO, FilePath, Handle, BufferMode(..))
@@ -73,8 +73,7 @@ import qualified System.Posix.Types   as Posix
 import qualified System.Posix.Process as Posix
 import qualified System.Posix.Signals as Signals
 
-import           X.Control.Monad.Trans.Either (EitherT, pattern EitherT)
-import           X.Control.Monad.Trans.Either (hoistEither, left)
+import           Control.Monad.Trans.Either
 
 ------------------------------------------------------------------------
 
@@ -346,7 +345,7 @@ call :: (ProcessResult a, Functor m, MonadIO m, MonadCatch m)
      -> [Argument]
      -> EitherT e m a
 
-call up cmd args = firstT up (callProcess process)
+call up cmd args = firstEitherT up (callProcess process)
   where
     process = Process { processCommand     = cmd
                       , processArguments   = args
@@ -374,7 +373,7 @@ callFrom :: (ProcessResult a, Functor m, MonadIO m, MonadCatch m)
          -> [Argument]
          -> EitherT e m a
 
-callFrom up dir cmd args = firstT up (callProcess process)
+callFrom up dir cmd args = firstEitherT up (callProcess process)
   where
     process = Process { processCommand     = cmd
                       , processArguments   = args
@@ -429,7 +428,7 @@ exec :: (Functor m, MonadIO m, MonadCatch m)
      -> [Argument]
      -> EitherT e m a
 
-exec up cmd args = firstT up (execProcess process)
+exec up cmd args = firstEitherT up (execProcess process)
   where
     process = Process { processCommand     = cmd
                       , processArguments   = args
@@ -445,7 +444,7 @@ execFrom :: (Functor m, MonadIO m, MonadCatch m)
          -> [Argument]
          -> EitherT e m a
 
-execFrom up dir cmd args = firstT up (execProcess process)
+execFrom up dir cmd args = firstEitherT up (execProcess process)
   where
     process = Process { processCommand     = cmd
                       , processArguments   = args
@@ -503,7 +502,7 @@ handleIO p =
   in handle (hoistEither . Left . ProcessException p . fromIO)
 
 waitCatchE :: (Functor m, MonadIO m) => Process -> Async a -> EitherT ProcessError m a
-waitCatchE p = firstT (ProcessException p) . EitherT . liftIO . waitCatch
+waitCatchE p = firstEitherT (ProcessException p) . EitherT . liftIO . waitCatch
 
 ------------------------------------------------------------------------
 

--- a/src/Mafia/Script.hs
+++ b/src/Mafia/Script.hs
@@ -28,11 +28,11 @@ import           Mafia.IO
 import           Mafia.Path
 import           Mafia.Process
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 
-import           X.Control.Monad.Trans.Either (EitherT, hoistMaybe, hoistEither)
+import           Control.Monad.Trans.Either (EitherT, hoistMaybe, hoistEither)
 
 
 data Script =

--- a/src/Mafia/Script.hs
+++ b/src/Mafia/Script.hs
@@ -15,8 +15,6 @@ module Mafia.Script (
   , renderPragmaSubmodule
   ) where
 
-import           Control.Monad.IO.Class (MonadIO(..))
-
 import qualified Data.Attoparsec.Text as Atto
 import           Data.Char (isSpace)
 import qualified Data.Map as Map

--- a/src/Mafia/Submodule.hs
+++ b/src/Mafia/Submodule.hs
@@ -28,12 +28,12 @@ import           Mafia.IO
 import           Mafia.Path
 import           Mafia.Process
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO, stderr)
 
-import           X.Control.Monad.Trans.Either (EitherT)
-
+import           Control.Monad.Trans.Bifunctor
+import           Control.Monad.Trans.Either (EitherT)
 
 data SubmoduleError =
     SubmoduleCabalError CabalError

--- a/src/Mafia/Submodule.hs
+++ b/src/Mafia/Submodule.hs
@@ -15,8 +15,6 @@ module Mafia.Submodule (
   , getSourcesFrom
   ) where
 
-import           Control.Monad.IO.Class (MonadIO(..))
-
 import           Data.Set (Set)
 import qualified Data.Set as Set
 import qualified Data.Text as T
@@ -32,7 +30,7 @@ import           Mafia.P
 
 import           System.IO (IO, stderr)
 
-import           Control.Monad.Trans.Bifunctor
+import           Control.Monad.Trans.Bifunctor (firstT)
 import           Control.Monad.Trans.Either (EitherT)
 
 data SubmoduleError =

--- a/src/Mafia/Tree.hs
+++ b/src/Mafia/Tree.hs
@@ -11,8 +11,7 @@ import qualified Data.Text.Lazy as Lazy
 
 import           Mafia.Cabal
 
-import           P hiding (Last)
-
+import           Mafia.P
 
 data Loc =
     Mid

--- a/src/Mafia/Twine.hs
+++ b/src/Mafia/Twine.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Mafia.Twine (
+    module X
+  ) where
+
+import           Mafia.Twine.Parallel as X
+import           Mafia.Twine.Queue as X

--- a/src/Mafia/Twine/Async.hs
+++ b/src/Mafia/Twine/Async.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Mafia.Twine.Async (
+    AsyncTimeout (..)
+  , renderAsyncTimeout
+  , waitWithTimeout
+  , waitEitherBoth
+  ) where
+
+import           Control.Concurrent.Async (Async, waitSTM, waitEither)
+import           Control.Concurrent.Async (async, cancel, wait)
+import           Control.Concurrent.STM (atomically, orElse, retry)
+import           Control.Exception.Base (AsyncException (..))
+import           Control.Monad.Catch (catch, throwM)
+
+import           Control.Monad.IO.Class (liftIO)
+
+import           Data.IORef (newIORef, readIORef, writeIORef)
+import qualified Data.Text as T
+
+import           P
+
+import           Mafia.Twine.Snooze
+
+import           System.IO (IO)
+
+import           X.Control.Monad.Trans.Either
+
+data AsyncTimeout =
+  AsyncTimeout Duration
+  deriving (Eq, Show)
+
+renderAsyncTimeout :: AsyncTimeout -> Text
+renderAsyncTimeout e =
+  case e of
+    AsyncTimeout d ->
+      mconcat [
+          "Async took greater than '"
+        , T.pack . show $ toSeconds d
+        , " seconds' to return."
+        ]
+
+waitWithTimeout :: Async a -> Duration -> EitherT AsyncTimeout IO a
+waitWithTimeout a d = do
+  r <- liftIO $ newIORef False
+  s <- liftIO . async $ snooze d
+  e <- liftIO $ waitEither a s
+  case e of
+    Left a' ->
+      pure $ a'
+    Right _ -> do
+      liftIO $ writeIORef r True
+      liftIO $ cancel a
+      (liftIO $ wait a)
+        `catch`
+          (\(ae :: AsyncException) ->
+            case ae of
+              ThreadKilled -> do
+                liftIO (readIORef r) >>=
+                  bool (liftIO $ throwM ae) (left $ AsyncTimeout d)
+              StackOverflow ->
+                liftIO $ throwM ae
+              HeapOverflow ->
+                liftIO $ throwM ae
+              UserInterrupt ->
+                liftIO $ throwM ae)
+
+waitEitherBoth :: Async a -> Async b -> Async c -> IO (Either a (b, c))
+waitEitherBoth a b c =
+  atomically $ do
+    let
+      l = waitSTM a
+      r = do
+        bb <- waitSTM b `orElse` (waitSTM c >> retry)
+        cc <- waitSTM c
+        return (bb, cc)
+    fmap Left l `orElse` fmap Right r

--- a/src/Mafia/Twine/Async.hs
+++ b/src/Mafia/Twine/Async.hs
@@ -14,8 +14,6 @@ import           Control.Concurrent.STM (atomically, orElse, retry)
 import           Control.Exception.Base (AsyncException (..))
 import           Control.Monad.Catch (catch, throwM)
 
-import           Control.Monad.IO.Class (liftIO)
-
 import           Data.IORef (newIORef, readIORef, writeIORef)
 import qualified Data.Text as T
 

--- a/src/Mafia/Twine/Async.hs
+++ b/src/Mafia/Twine/Async.hs
@@ -19,7 +19,7 @@ import           Control.Monad.IO.Class (liftIO)
 import           Data.IORef (newIORef, readIORef, writeIORef)
 import qualified Data.Text as T
 
-import           P
+import           Mafia.P
 
 import           Mafia.Twine.Snooze
 

--- a/src/Mafia/Twine/Async.hs
+++ b/src/Mafia/Twine/Async.hs
@@ -25,7 +25,7 @@ import           Mafia.Twine.Snooze
 
 import           System.IO (IO)
 
-import           X.Control.Monad.Trans.Either
+import           Control.Monad.Trans.Either
 
 data AsyncTimeout =
   AsyncTimeout Duration

--- a/src/Mafia/Twine/Parallel.hs
+++ b/src/Mafia/Twine/Parallel.hs
@@ -1,0 +1,215 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ExplicitForAll #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Mafia.Twine.Parallel (
+    RunError (..)
+  , renderRunError
+  , consume_
+  , consume
+  , waitEitherBoth
+
+
+  , Workers
+  , Result
+  , newResult
+  , emptyResult
+  , addResult
+  , getResult
+  , emptyWorkers
+  , failWorkers
+  , getWorkers
+  , addWorker
+  , waitForWorkers
+  , waitForWorkers'
+  ) where
+
+import           Control.Concurrent.MVar (newEmptyMVar, newMVar, takeMVar
+                                         , putMVar, modifyMVar, modifyMVar_,readMVar, MVar)
+import           Control.Concurrent (threadDelay)
+import           Control.Concurrent.Async (async, cancel, poll, waitBoth, wait, waitEither, Async)
+import           Control.Concurrent.MSem (new, signal)
+import qualified Control.Concurrent.MSem as M
+import           Control.Monad.Catch
+import           Control.Monad.IO.Class
+import           Control.Monad.Loops (untilM_)
+import qualified Data.Text as T
+import           Data.Typeable
+
+import           P
+
+import           Mafia.Twine.Async (waitEitherBoth)
+import           Mafia.Twine.Queue
+
+import           System.IO
+
+import           X.Control.Monad.Trans.Either
+
+newtype Result a =
+  Result (MVar a)
+
+newResult :: a -> IO (Result a)
+newResult a =
+  Result <$> newMVar a
+
+-- fix pair with takeMVar
+emptyResult :: IO (Result a)
+emptyResult =
+  Result <$> newEmptyMVar
+
+addResult :: Monad m => Result (m a) -> m a -> IO (m a)
+addResult (Result r) w =
+  modifyMVar r (\x -> pure $ ((x >> w), x))
+
+getResult :: Result a -> IO a
+getResult (Result r) =
+  readMVar r
+
+newtype Workers a =
+  Workers (MVar [Async a])
+
+emptyWorkers :: IO (Workers a)
+emptyWorkers =
+  Workers <$> newMVar []
+
+failWorkers :: Workers a -> IO ()
+failWorkers (Workers w) =
+  readMVar w >>=
+    mapM_ cancel
+
+getWorkers :: Workers a -> IO [Async a]
+getWorkers (Workers w) =
+  readMVar w
+
+addWorker :: (Workers a) -> Async a -> IO ()
+addWorker (Workers w) r =
+  modifyMVar_ w $ pure . (:) r
+
+waitForWorkers :: (Workers a) -> IO ()
+waitForWorkers (Workers w) =
+  readMVar w >>= mapM_ wait
+
+waitForWorkers' :: (Workers a) -> IO [a]
+waitForWorkers' (Workers w) =
+  readMVar w >>= mapM wait
+
+-- | Provide a producer and an action to be run across the result
+--   of that producer in parallel.
+--
+--
+--   Common usage:
+--   @
+--     let producer :: Address -> Queue Address -> IO ()
+--         producer prefix q =
+--           list' prefix $$ writeQueue q
+--
+--     consume producer 100 (\(a :: Address) -> doThis)
+--   @
+--
+consume_ :: MonadIO m => (Queue b -> IO a) -> Int -> (b -> EitherT e IO ()) -> EitherT (RunError e) m a
+consume_ pro fork action = EitherT . liftIO $ do
+  q <- newQueue fork
+
+  producer <- async $ pro q
+
+  workers <- emptyWorkers
+  result <- newResult $ Right ()
+  sem <- new fork
+
+  let spawn = do
+       m <- tryReadQueue q
+       flip (maybe $ return ()) m $ \a -> do
+         w <- do
+           M.wait sem
+           async $ (runEitherT (action a) >>= void . addResult result . first WorkerError) `finally` signal sem
+         addWorker workers w
+
+  let check = do
+       threadDelay 1000 {-- 1 ms --}
+       p <- poll producer
+       e <- isQueueEmpty q
+       pure $ (isJust p) && e
+
+  submitter <- async $ untilM_ spawn check
+
+  -- early termination
+  void . async . forever $ do
+    threadDelay 1000000 {-- 1 second --}
+    getResult result >>=
+      either (const $ cancel producer >> cancel submitter) pure
+
+  let waiter = do
+        (i, _) <- waitBoth producer submitter
+        waitForWorkers workers
+        pure i
+
+  (waiter >>= \i -> getResult result >>= pure . second (const $ i))
+    `catchAll` (\z ->
+      failWorkers workers >>
+        getResult result >>= \w ->
+          pure (w >> Left (BlowUpError z)))
+
+data RunError a =
+    WorkerError a
+  | BlowUpError SomeException
+  deriving Show
+
+renderRunError :: RunError a -> (a -> Text) -> Text
+renderRunError r render =
+  case r of
+    WorkerError a ->
+      "Worker failed: " <> render a
+    BlowUpError e ->
+      "An unknown exception was caught: " <> T.pack (show e)
+
+data EarlyTermination =
+  EarlyTermination deriving (Eq, Show, Typeable)
+
+instance Exception EarlyTermination
+
+consume :: forall a b c e . (Queue a -> IO b) -> Int -> (a -> IO (Either e c)) -> IO (Either (RunError e) (b, [c]))
+consume pro fork action = flip catchAll (pure . Left . BlowUpError) $ do
+  q <- newQueue fork -- not fork
+  producer <- async $ pro q
+  workers <- (emptyWorkers :: IO (Workers c))
+  sem <- new fork
+  early <- newEmptyMVar
+
+  terminator <- async $ takeMVar early
+
+  let spawn :: IO ()
+      spawn = do
+       m <- tryReadQueue q
+       flip (maybe $ return ()) m $ \a -> do
+         w <- do
+           M.wait sem
+           async $ flip finally (signal sem) $ do
+             r <- action a
+             case r of
+               Left e ->
+                 putMVar early e >>
+                   throwM EarlyTermination
+               Right c ->
+                 pure $! c
+         addWorker workers w
+
+  let check = do
+       threadDelay 1000 {-- 1 ms --}
+       p <- poll producer
+       e <- isQueueEmpty q
+       pure $ (isJust p) && e
+
+  submitter <- async $ untilM_ spawn check
+
+  let waiter = runEitherT $ do
+        (i, _) <- bimapEitherT WorkerError id . EitherT $ waitEitherBoth terminator producer submitter
+
+        ws <- liftIO $ getWorkers workers
+        ii <- mapM (bimapEitherT WorkerError id . EitherT . waitEither terminator) ws
+        pure $ (i, ii)
+
+  waiter `catch` (\(_ :: EarlyTermination) ->
+    failWorkers workers >>
+      (Left . WorkerError) <$> wait terminator)

--- a/src/Mafia/Twine/Parallel.hs
+++ b/src/Mafia/Twine/Parallel.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE ExplicitForAll #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-
 module Mafia.Twine.Parallel (
     RunError (..)
   , renderRunError
@@ -38,7 +37,7 @@ import           Control.Monad.Loops (untilM_)
 import qualified Data.Text as T
 import           Data.Typeable
 
-import           P
+import           Mafia.P
 
 import           Mafia.Twine.Async (waitEitherBoth)
 import           Mafia.Twine.Queue

--- a/src/Mafia/Twine/Parallel.hs
+++ b/src/Mafia/Twine/Parallel.hs
@@ -44,7 +44,7 @@ import           Mafia.Twine.Queue
 
 import           System.IO
 
-import           X.Control.Monad.Trans.Either
+import           Control.Monad.Trans.Either
 
 newtype Result a =
   Result (MVar a)

--- a/src/Mafia/Twine/Queue.hs
+++ b/src/Mafia/Twine/Queue.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Mafia.Twine.Queue (
+    Queue
+  , newQueue
+  , readQueue
+  , tryReadQueue
+  , writeQueue
+  , isQueueEmpty
+  ) where
+
+import           Control.Concurrent.STM.TBQueue (TBQueue, newTBQueue, tryReadTBQueue, readTBQueue, writeTBQueue, isEmptyTBQueue)
+
+import           GHC.Conc (atomically)
+
+import           P
+
+import           System.IO
+
+newtype Queue a =
+  Queue {
+      queue :: TBQueue a
+    }
+
+newQueue :: Int -> IO (Queue a)
+newQueue i =
+  atomically $ Queue <$> newTBQueue i
+
+readQueue :: Queue a -> IO a
+readQueue =
+  atomically . readTBQueue . queue
+
+tryReadQueue :: Queue a -> IO (Maybe a)
+tryReadQueue =
+  atomically . tryReadTBQueue . queue
+
+writeQueue :: Queue a -> a -> IO ()
+writeQueue q =
+  atomically . writeTBQueue (queue q)
+
+isQueueEmpty :: Queue a -> IO Bool
+isQueueEmpty =
+  atomically . isEmptyTBQueue . queue

--- a/src/Mafia/Twine/Queue.hs
+++ b/src/Mafia/Twine/Queue.hs
@@ -8,11 +8,12 @@ module Mafia.Twine.Queue (
   , isQueueEmpty
   ) where
 
-import           Control.Concurrent.STM.TBQueue (TBQueue, newTBQueue, tryReadTBQueue, readTBQueue, writeTBQueue, isEmptyTBQueue)
+import           Control.Concurrent.STM.TBQueue (TBQueue, newTBQueue, tryReadTBQueue
+                                                , readTBQueue, writeTBQueue, isEmptyTBQueue)
 
 import           GHC.Conc (atomically)
 
-import           P
+import           Mafia.P
 
 import           System.IO
 

--- a/src/Mafia/Twine/Snooze.hs
+++ b/src/Mafia/Twine/Snooze.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Mafia.Twine.Snooze (
+    snooze
+  , Duration (..)
+  , toMicroseconds
+  , toMilliseconds
+  , toSeconds
+  ) where
+
+import           Control.Concurrent
+
+import           P
+
+import           System.IO
+
+-- |
+-- A Duration is an abstract type, representing a short delay (in the
+-- region of micro-seconds to a few minutes).
+--
+-- This useful for implementing concurrency and process primitives
+-- that need to wait for short periods to ensure fairness (for example).
+--
+newtype Duration =
+  Duration {
+      duration :: Int
+    } deriving (Eq, Show)
+
+toMicroseconds :: Duration -> Int
+toMicroseconds =
+  duration
+
+toMilliseconds :: Duration -> Int
+toMilliseconds =
+  flip div 1000 . toMicroseconds
+
+toSeconds :: Duration -> Int
+toSeconds =
+  flip div 1000 . toMilliseconds
+
+snooze :: Duration -> IO ()
+snooze =
+  threadDelay . toMicroseconds

--- a/src/Mafia/Twine/Snooze.hs
+++ b/src/Mafia/Twine/Snooze.hs
@@ -9,7 +9,7 @@ module Mafia.Twine.Snooze (
 
 import           Control.Concurrent
 
-import           P
+import           Mafia.P
 
 import           System.IO
 

--- a/test/Test/IO/Mafia/Chaos.hs
+++ b/test/Test/IO/Mafia/Chaos.hs
@@ -12,8 +12,8 @@ import           Control.Exception (IOException)
 import           Control.Monad.Catch (MonadCatch(..), MonadMask(..), bracket, handle)
 import           Control.Monad.IO.Class (MonadIO(..))
 
-import           Disorder.Corpus (muppets, viruses)
-import           Disorder.Core.IO (testIO)
+import           Test.Mafia.Corpus (muppets, viruses)
+import           Test.Mafia.IO (testIO)
 
 import           Data.Char (toUpper)
 import           Data.Map (Map)

--- a/test/Test/IO/Mafia/Chaos.hs
+++ b/test/Test/IO/Mafia/Chaos.hs
@@ -10,7 +10,9 @@ module Test.IO.Mafia.Chaos where
 
 import           Control.Exception (IOException)
 import           Control.Monad.Catch (MonadCatch(..), MonadMask(..), bracket, handle)
-import           Control.Monad.IO.Class (MonadIO(..))
+import           Control.Monad.Trans.Bifunctor (firstT)
+import           Control.Monad.Trans.Either (EitherT, runEitherT)
+import           Control.Monad.Trans.Either (hoistEither)
 
 import           Test.Mafia.Corpus (muppets, viruses)
 import           Test.Mafia.IO (testIO)
@@ -37,10 +39,6 @@ import           System.IO (IO, print)
 import           Test.QuickCheck (Arbitrary(..), Gen, Property, Testable(..))
 import           Test.QuickCheck (forAllProperties)
 import qualified Test.QuickCheck as QC
-
-import           Control.Monad.Trans.Either (EitherT, runEitherT)
-import           Control.Monad.Trans.Either (hoistEither)
-import           Control.Monad.Trans.Bifunctor
 
 ------------------------------------------------------------------------
 

--- a/test/Test/IO/Mafia/Chaos.hs
+++ b/test/Test/IO/Mafia/Chaos.hs
@@ -23,14 +23,14 @@ import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
+import           Mafia.Catch (bracketEitherT')
 import           Mafia.Git
 import           Mafia.IO
+import           Mafia.P
 import           Mafia.Path
-import           Mafia.Process (ProcessError, ProcessResult, Argument)
 import           Mafia.Process (Hush(..), Pass(..))
+import           Mafia.Process (ProcessError, ProcessResult, Argument)
 import           Mafia.Process (call_, callFrom)
-
-import           P
 
 import           System.IO (IO, print)
 
@@ -38,8 +38,9 @@ import           Test.QuickCheck (Arbitrary(..), Gen, Property, Testable(..))
 import           Test.QuickCheck (forAllProperties)
 import qualified Test.QuickCheck as QC
 
-import           X.Control.Monad.Trans.Either (EitherT, runEitherT)
-import           X.Control.Monad.Trans.Either (hoistEither, bracketEitherT')
+import           Control.Monad.Trans.Either (EitherT, runEitherT)
+import           Control.Monad.Trans.Either (hoistEither)
+import           Control.Monad.Trans.Bifunctor
 
 ------------------------------------------------------------------------
 

--- a/test/Test/IO/Mafia/Flock.hs
+++ b/test/Test/IO/Mafia/Flock.hs
@@ -16,7 +16,7 @@ import           Disorder.Core.IO
 import           Mafia.Flock
 import           Mafia.Path
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 import qualified System.IO.Temp as Temp
@@ -24,7 +24,7 @@ import qualified System.IO.Temp as Temp
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
 
-import           X.Control.Monad.Trans.Either (runEitherT)
+import           Control.Monad.Trans.Either (runEitherT)
 
 
 prop_flock :: Property

--- a/test/Test/IO/Mafia/Flock.hs
+++ b/test/Test/IO/Mafia/Flock.hs
@@ -11,7 +11,7 @@ import           Control.Monad.IO.Class (liftIO)
 import           Data.IORef (newIORef, modifyIORef', readIORef)
 import qualified Data.Text as T
 
-import           Disorder.Core.IO
+import           Test.Mafia.IO (testIO)
 
 import           Mafia.Flock
 import           Mafia.Path

--- a/test/Test/IO/Mafia/Flock.hs
+++ b/test/Test/IO/Mafia/Flock.hs
@@ -6,7 +6,7 @@ module Test.IO.Mafia.Flock where
 import           Control.Concurrent (threadDelay)
 import           Control.Concurrent.MVar (newEmptyMVar, readMVar, putMVar)
 import           Control.Concurrent.Async (async, mapConcurrently, wait)
-import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Trans.Either (runEitherT)
 
 import           Data.IORef (newIORef, modifyIORef', readIORef)
 import qualified Data.Text as T
@@ -15,7 +15,6 @@ import           Test.Mafia.IO (testIO)
 
 import           Mafia.Flock
 import           Mafia.Path
-
 import           Mafia.P
 
 import           System.IO (IO)
@@ -23,9 +22,6 @@ import qualified System.IO.Temp as Temp
 
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()
-
-import           Control.Monad.Trans.Either (runEitherT)
-
 
 prop_flock :: Property
 prop_flock =

--- a/test/Test/Mafia/Arbitrary.hs
+++ b/test/Test/Mafia/Arbitrary.hs
@@ -14,7 +14,7 @@ import           Mafia.Cabal.Constraint
 import           Mafia.Cabal.Types
 import           Mafia.Package
 
-import           P
+import           Mafia.P
 
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()

--- a/test/Test/Mafia/Arbitrary.hs
+++ b/test/Test/Mafia/Arbitrary.hs
@@ -8,7 +8,7 @@ module Test.Mafia.Arbitrary where
 import qualified Data.List as DL
 import qualified Data.Text as T
 
-import           Disorder.Corpus (muppets, cooking)
+import           Test.Mafia.Corpus (muppets, cooking)
 
 import           Mafia.Cabal.Constraint
 import           Mafia.Cabal.Types

--- a/test/Test/Mafia/Cabal/Constraint.hs
+++ b/test/Test/Mafia/Cabal/Constraint.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Test.Mafia.Cabal.Constraint where
 
-import           Disorder.Core.Tripping (tripping)
+import           Test.Mafia.Tripping (tripping)
 
 import           Mafia.Cabal.Constraint
 

--- a/test/Test/Mafia/Cabal/Constraint.hs
+++ b/test/Test/Mafia/Cabal/Constraint.hs
@@ -7,7 +7,7 @@ import           Disorder.Core.Tripping (tripping)
 
 import           Mafia.Cabal.Constraint
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 

--- a/test/Test/Mafia/Cabal/Dependencies.hs
+++ b/test/Test/Mafia/Cabal/Dependencies.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Test.Mafia.Cabal.Dependencies where
 
-import           Disorder.Core.Tripping (tripping)
+import           Test.Mafia.Tripping (tripping)
 
 import           Mafia.Cabal.Dependencies
 import           Mafia.Cabal.Types

--- a/test/Test/Mafia/Cabal/Dependencies.hs
+++ b/test/Test/Mafia/Cabal/Dependencies.hs
@@ -8,7 +8,7 @@ import           Disorder.Core.Tripping (tripping)
 import           Mafia.Cabal.Dependencies
 import           Mafia.Cabal.Types
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 

--- a/test/Test/Mafia/Cabal/Types.hs
+++ b/test/Test/Mafia/Cabal/Types.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Test.Mafia.Cabal.Types where
 
-import           Disorder.Core.Tripping (tripping)
+import           Test.Mafia.Tripping (tripping)
 
 import           Mafia.Cabal.Types
 

--- a/test/Test/Mafia/Cabal/Types.hs
+++ b/test/Test/Mafia/Cabal/Types.hs
@@ -7,7 +7,7 @@ import           Disorder.Core.Tripping (tripping)
 
 import           Mafia.Cabal.Types
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 

--- a/test/Test/Mafia/Corpus.hs
+++ b/test/Test/Mafia/Corpus.hs
@@ -1,0 +1,755 @@
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Test.Mafia.Corpus (
+    agile
+  , animals
+  , boats
+  , cats
+  , colours
+  , cooking
+  , fruits
+  , glass
+  , muppets
+  , nfl
+  , nhl
+  , simpsons
+  , southpark
+  , vegetables
+  , viruses
+  , waters
+  , weather
+
+  -- * Deprecated
+  , genCorpus
+  , shrinkCorpus
+  , Cooking(..)
+  , unCooking
+  , Muppet(..)
+  , unMuppet
+  , Southpark(..)
+  , unSouthpark
+  , Simpson(..)
+  , unSimpson
+  , Virus(..)
+  , unVirus
+  , Colour(..)
+  , unColour
+  , Weather(..)
+  , unWeather
+  , Water(..)
+  , unWater
+  , Boat(..)
+  , unBoat
+  , Glass(..)
+  , unGlass
+  ) where
+
+import           Data.Data (Data)
+import           Data.Eq (Eq)
+import           Data.Functor (fmap)
+import qualified Data.List as List
+import           Data.Monoid ((<>))
+import           Data.Ord (Ord)
+import           Data.String (IsString(..))
+import           Data.Typeable (Typeable)
+
+import           GHC.Generics (Generic)
+
+import           Test.QuickCheck (Arbitrary(..), Gen, oneof, elements)
+
+import           Text.Show (Show)
+import           Text.Read (Read)
+
+
+cooking :: IsString a => [a]
+cooking = [
+    "salted"
+  , "stewed"
+  , "diced"
+  , "filleted"
+  , "sauteed"
+  ]
+
+muppets :: IsString a => [a]
+muppets = [
+    "kermit"
+  , "gonzo"
+  , "fozzy"
+  , "chef"
+  , "statler"
+  , "waldorf"
+  , "beaker"
+  , "animal"
+  ]
+
+southpark :: IsString a => [a]
+southpark = [
+    "kyle"
+  , "stan"
+  , "cartman"
+  , "timmy"
+  , "token"
+  , "chef"
+  , "garrison"
+  ]
+
+simpsons :: IsString a => [a]
+simpsons = [
+    "homer"
+  , "marge"
+  , "maggie"
+  , "lisa"
+  , "bart"
+  , "flanders"
+  , "moe"
+  , "barney"
+  ]
+
+viruses :: IsString a => [a]
+viruses = [
+    "rotavirus"
+  , "smallpox"
+  , "norovirus"
+  , "chickenpox"
+  , "camelpox"
+  , "dengue"
+  , "echovirus"
+  , "equine morbillivirus"
+  , "gou virus"
+  , "measles"
+  , "monkeypox"
+  ]
+
+colours :: IsString a => [a]
+colours = [
+    "red"
+  , "green"
+  , "blue"
+  , "yellow"
+  , "black"
+  , "grey"
+  , "purple"
+  , "orange"
+  , "pink"
+  ]
+
+weather :: IsString a => [a]
+weather = [
+    "dry"
+  , "raining"
+  , "hot"
+  , "humid"
+  , "snowing"
+  , "fresh"
+  , "windy"
+  , "freezing"
+  ]
+
+waters :: IsString a => [a]
+waters = [
+    "basin"
+  , "bay"
+  , "billabong"
+  , "canal"
+  , "channel"
+  , "creek"
+  , "estuary"
+  , "fjord"
+  , "harbour"
+  , "lake"
+  , "loch"
+  , "marsh"
+  , "ocean"
+  , "pond"
+  , "puddle"
+  , "reservoir"
+  , "river"
+  , "sea"
+  , "slough"
+  , "sound"
+  , "spring"
+  , "stream"
+  , "swamp"
+  , "wetland"
+  ]
+
+boats :: IsString a => [a]
+boats = [
+    "barge"
+  , "battleship"
+  , "canoe"
+  , "catamaran"
+  , "dinghy"
+  , "ferry"
+  , "gondola"
+  , "jetski"
+  , "kayak"
+  , "longship"
+  , "motorboat"
+  , "pontoon"
+  , "powerboat"
+  , "rowboat"
+  , "ship"
+  , "steamboat"
+  , "tanker"
+  , "trawler"
+  , "tugboat"
+  , "yacht"
+  ]
+
+animals :: IsString a => [a]
+animals = [
+    "alligator"
+  , "ant"
+  , "bear"
+  , "bee"
+  , "bird"
+  , "camel"
+  , "cat"
+  , "cheetah"
+  , "chicken"
+  , "chimpanzee"
+  , "cow"
+  , "crocodile"
+  , "deer"
+  , "dog"
+  , "dolphin"
+  , "duck"
+  , "eagle"
+  , "elephant"
+  , "fish"
+  , "fly"
+  , "fox"
+  , "frog"
+  , "giraffe"
+  , "goat"
+  , "goldfish"
+  , "hamster"
+  , "hippopotamus"
+  , "horse"
+  , "kangaroo"
+  , "kitten"
+  , "lion"
+  , "lobster"
+  , "monkey"
+  , "octopus"
+  , "owl"
+  , "panda"
+  , "pig"
+  , "puppy"
+  , "rabbit"
+  , "rat"
+  , "scorpion"
+  , "seal"
+  , "shark"
+  , "sheep"
+  , "snail"
+  , "snake"
+  , "spider"
+  , "squirrel"
+  , "tiger"
+  , "turtle"
+  , "wolf"
+  , "zebra"
+  ]
+
+vegetables :: IsString a => [a]
+vegetables = [
+    "asparagus"
+  , "beans"
+  , "broccoli"
+  , "cabbage"
+  , "carrot"
+  , "celery"
+  , "corn"
+  , "cucumber"
+  , "eggplant"
+  , "green pepper"
+  , "lettuce"
+  , "onion"
+  , "peas"
+  , "potato"
+  , "pumpkin"
+  , "radish"
+  , "spinach"
+  , "sweet potato"
+  , "tomato" -- Don't be so pedantic! It's a culinary vegetable.
+  , "turnip"
+  ]
+
+fruits :: IsString a => [a]
+fruits = [
+    "apple"
+  , "banana"
+  , "cherry"
+  , "grapefruit"
+  , "grapes"
+  , "lemon"
+  , "lime"
+  , "melon"
+  , "orange"
+  , "peach"
+  , "pear"
+  , "persimmon"
+  , "pineapple"
+  , "plum"
+  , "strawberry"
+  , "tangerine"
+  , "watermelon"
+  ]
+
+cats :: IsString a => [a]
+cats = [
+    "american_curl"
+  , "american_shorthair"
+  , "angora"
+  , "british_shorthair"
+  , "bobtail"
+  , "exotic_shorthair"
+  , "himalayan"
+  , "maine_coon"
+  , "munchkin"
+  , "norwegian_forest"
+  , "persian"
+  , "ragamuffin"
+  , "ragdoll"
+  , "russian_blue"
+  , "scottish_fold"
+  , "siamese"
+  , "siberian"
+  , "tabby"
+  ]
+
+nhl :: IsString a => [a]
+nhl = [
+    "Anaheim Ducks"
+  , "Arizona Coyotes"
+  , "Boston Bruins"
+  , "Buffalo Sabres"
+  , "Calgary Flames"
+  , "Carolina Hurricanes"
+  , "Chicago Blackhawks"
+  , "Colorado Avalanche"
+  , "Columbus Blue Jackets"
+  , "Dallas Stars"
+  , "Detroit Red Wings"
+  , "Edmonton Oilers"
+  , "Florida Panthers"
+  , "Los Angeles Kings"
+  , "Minnesota Wild"
+  , "Montréal Canadiens"
+  , "Nashville Predators"
+  , "New Jersey Devils"
+  , "New York Islanders"
+  , "New York Rangers"
+  , "Ottawa Senators"
+  , "Philadelphia Flyers"
+  , "Pittsburgh Penguins"
+  , "San Jose Sharks"
+  , "St. Louis Blues"
+  , "Tampa Bay Lightning"
+  , "Toronto Maple Leafs"
+  , "Vancouver Canucks"
+  , "Vegas Golden Knights"
+  , "Washington Capitals"
+  , "Winnipeg Jets"
+  ]
+
+nfl :: IsString a => [a]
+nfl = [
+    "Arizona Cardinals"
+  , "Atlanta Falcons"
+  , "Baltimore Ravens"
+  , "Buffalo Bills"
+  , "Carolina Panthers"
+  , "Chicago Bears"
+  , "Cincinnati Bengals"
+  , "Cleveland Browns"
+  , "Dallas Cowboys"
+  , "Denver Broncos"
+  , "Detroit Lions"
+  , "Green Bay Packers"
+  , "Houston Texans"
+  , "Indianapolis Colts"
+  , "Jacksonville Jaguars"
+  , "Kansas City Chiefs"
+  , "Miami Dolphins"
+  , "Minnesota Vikings"
+  , "New England Patriots"
+  , "New Orleans Saints"
+  , "New York Giants"
+  , "New York Jets"
+  , "Oakland Raiders"
+  , "Philadelphia Eagles"
+  , "Pittsburgh Steelers"
+  , "San Diego Chargers"
+  , "San Francisco 49ers"
+  , "Seattle Seahawks"
+  , "St. Louis Rams"
+  , "Tampa Bay Buccaneers"
+  , "Tennessee Titans"
+  , "Washington Redskins"
+  ]
+
+agile :: IsString a => [a]
+agile = [
+    "agile"
+  , "backlog"
+  , "burn-down chart"
+  , "epic"
+  , "extreme programming"
+  , "information radiator"
+  , "kanban"
+  , "lean"
+  , "pair programming"
+  , "planning poker"
+  , "product owner"
+  , "retrospective"
+  , "scrum"
+  , "scrum master"
+  , "spike"
+  , "sprint"
+  , "standup"
+  , "story points"
+  , "test driven"
+  , "user story"
+  , "velocity"
+  , "vertical slice"
+  ]
+
+-- | How to say "I can eat glass, and it doesn't hurt me." in a few different
+--   languages.
+--
+--   From: http://kermitproject.org/utf8.html
+--
+glass :: IsString a => [a]
+glass = [
+    "काचं शक्नोम्यत्तुम् । नोपहिनस्ति माम् ॥" -- Sanskrit
+  , "kācaṃ śaknomyattum; nopahinasti mām." -- Sanskrit (standard transcription)
+  , "ὕαλον ϕαγεῖν δύναμαι· τοῦτο οὔ με βλάπτει." -- Classical Greek
+  , "Μπορώ να φάω σπασμένα γυαλιά χωρίς να πάθω τίποτα." -- Greek (monotonic)
+  , "Μπορῶ νὰ φάω σπασμένα γυαλιὰ χωρὶς νὰ πάθω τίποτα. " -- Greek (polytonic)
+  , "Vitrum edere possum; mihi non nocet." -- Latin
+  , "Je puis mangier del voirre. Ne me nuit." -- Old French
+  , "Je peux manger du verre, ça ne me fait pas mal." -- French
+  , "Pòdi manjar de veire, me nafrariá pas." -- Provençal / Occitan
+  , "J'peux manger d'la vitre, ça m'fa pas mal." -- Québécois
+  , "Dji pou magnî do vêre, çoula m' freut nén må. " -- Walloon
+  , "Ch'peux mingi du verre, cha m'foé mie n'ma. " -- Picard
+  , "Mwen kap manje vè, li pa blese'm." -- Kreyòl Ayisyen (Haitï)
+  , "Kristala jan dezaket, ez dit minik ematen." -- Basque
+  , "Puc menjar vidre, que no em fa mal." -- Catalan / Català
+  , "Puedo comer vidrio, no me hace daño." -- Spanish
+  , "Puedo minchar beire, no me'n fa mal . " -- Aragonés
+  , "Eu podo xantar cristais e non cortarme." -- Galician
+  , "Posso comer vidro, não me faz mal." -- European Portuguese
+  , "Posso comer vidro, não me machuca." -- Brazilian Portuguese
+  , "M' podê cumê vidru, ca ta maguâ-m '." --Caboverdiano/Kabuverdianu (Cape Verde)
+  , "Ami por kome glas anto e no ta hasimi daño." -- Papiamentu
+  , "Posso mangiare il vetro e non mi fa male." -- Italian
+  , "Sôn bôn de magnà el véder, el me fa minga mal." -- Milanese
+  , "Me posso magna' er vetro, e nun me fa male." -- Roman
+  , "M' pozz magna' o'vetr, e nun m' fa mal." -- Napoletano
+  , "Mi posso magnare el vetro, no'l me fa mae." -- Venetian
+  , "Pòsso mangiâ o veddro e o no me fà mâ." -- Zeneise (Genovese)
+  , "Puotsu mangiari u vitru, nun mi fa mali. " -- Sicilian
+  , "Jau sai mangiar vaider, senza che quai fa donn a mai. " -- Romansch (Grischun)
+  , "Pot să mănânc sticlă și ea nu mă rănește." -- Romanian
+  , "Mi povas manĝi vitron, ĝi ne damaĝas min. " -- Esperanto
+  , "Mý a yl dybry gwéder hag éf ny wra ow ankenya." -- Cornish
+  , "Dw i'n gallu bwyta gwydr, 'dyw e ddim yn gwneud dolur i mi." -- Welsh
+  , "Foddym gee glonney agh cha jean eh gortaghey mee." -- Manx Gaelic
+  , "᚛᚛ᚉᚑᚅᚔᚉᚉᚔᚋ ᚔᚈᚔ ᚍᚂᚐᚅᚑ ᚅᚔᚋᚌᚓᚅᚐ᚜" -- Old Irish (Ogham)
+  , "Con·iccim ithi nglano. Ním·géna." -- Old Irish (Latin)
+  , "Is féidir liom gloinne a ithe. Ní dhéanann sí dochar ar bith dom." -- Irish
+  , "Ithim-s a gloine agus ní miste damh é." --Ulster Gaelic
+  , "S urrainn dhomh gloinne ithe; cha ghoirtich i mi." -- Scottish Gaelic
+  , "ᛁᚳ᛫ᛗᚨᚷ᛫ᚷᛚᚨᛋ᛫ᛖᚩᛏᚪᚾ᛫ᚩᚾᛞ᛫ᚻᛁᛏ᛫ᚾᛖ᛫ᚻᛖᚪᚱᛗᛁᚪᚧ᛫ᛗᛖ᛬" -- Anglo-Saxon (Runes)
+  , "Ic mæg glæs eotan ond hit ne hearmiað me." -- Anglo-Saxon (Latin)
+  , "Ich canne glas eten and hit hirtiþ me nouȝt." -- Middle English
+  , "I can eat glass and it doesn't hurt me." -- English
+  , "[aɪ kæn iːt glɑːs ænd ɪt dɐz nɒt hɜːt miː]" -- English (IPA)
+  , "⠊⠀⠉⠁⠝⠀⠑⠁⠞⠀⠛⠇⠁⠎⠎⠀⠁⠝⠙⠀⠊⠞⠀⠙⠕⠑⠎⠝⠞⠀⠓⠥⠗⠞⠀⠍⠑" -- English (Braille)
+  , "Mi kian niam glas han i neba hot mi." -- Jamaican
+  , "Ah can eat gless, it disnae hurt us. " -- Lalland Scots / Doric
+  , "𐌼𐌰𐌲 𐌲𐌻𐌴𐍃 𐌹̈𐍄𐌰𐌽, 𐌽𐌹 𐌼𐌹𐍃 𐍅𐌿 𐌽𐌳𐌰𐌽 𐌱𐍂𐌹𐌲𐌲𐌹𐌸." -- Gothic
+  , "ᛖᚴ ᚷᛖᛏ ᛖᛏᛁ ᚧ ᚷᛚᛖᚱ ᛘᚾ ᚦᛖᛋᛋ ᚨᚧ ᚡᛖ ᚱᚧᚨ ᛋᚨᚱ" -- Old Norse (Runes)
+  , "Ek get etið gler án þess að verða sár." -- Old Norse (Latin)
+  , "Eg kan eta glas utan å skada meg." -- Norsk / Norwegian (Nynorsk)
+  , "Jeg kan spise glass uten å skade meg." -- Norsk / Norwegian (Bokmål)
+  , "Eg kann eta glas, skaðaleysur." -- Føroyskt / Faroese
+  , "Ég get etið gler án þess að meiða mig." -- Íslenska / Icelandic
+  , "Jag kan äta glas utan att skada mig." -- Svenska / Swedish
+  , "Jeg kan spise glas, det gør ikke ondt på mig." -- Dansk / Danish
+  , "Æ ka æe glass uhen at det go mæ naue." -- Sønderjysk
+  , "Ik kin glês ite, it docht me net sear." -- Frysk / Frisian
+  , "Ik kan glas eten, het doet mĳ geen kwaad." -- Nederlands / Dutch
+  , "Iech ken glaas èèse, mer 't deet miech jing pieng." -- Kirchröadsj/Bôchesserplat
+  , "Ek kan glas eet, maar dit doen my nie skade nie." -- Afrikaans
+  , "Ech kan Glas iessen, daat deet mir nët wei." -- Lëtzebuergescht / Luxemburgish
+  , "Ich kann Glas essen, ohne mir zu schaden." -- Deutsch / German
+  , "Ich kann Glas verkasematuckeln, ohne dattet mich wat jucken tut." -- Ruhrdeutsch
+  , "Isch kann Jlaas kimmeln, uuhne datt mich datt weh dääd." -- Langenfelder Platt
+  , "Ich koann Gloos assn und doas dudd merr ni wii." -- Lausitzer Mundart ("Lusatian")
+  , "Iech konn glaasch voschbachteln ohne dass es mir ebbs daun doun dud." -- Odenwälderisch
+  , "'sch kann Glos essn, ohne dass'sch mer wehtue." -- Sächsisch / Saxon
+  , "Isch konn Glass fresse ohne dasses mer ebbes ausmache dud." -- Pfälzisch
+  , "I kå Glas frässa, ond des macht mr nix!" -- Schwäbisch / Swabian
+  , "I ka glas eassa, ohne dass mar weh tuat." -- Deutsch (Voralberg)
+  , "I koh Glos esa, und es duard ma ned wei." -- Bayrisch / Bavarian
+  , "I kaun Gloos essen, es tuat ma ned weh." -- Allemannisch
+  , "Ich chan Glaas ässe, das schadt mir nöd." -- Schwyzerdütsch (Zürich)
+  , "Ech cha Glâs ässe, das schadt mer ned. " -- Schwyzerdütsch (Luzern)
+  , "Meg tudom enni az üveget, nem lesz tőle bajom." -- Hungarian
+  , "Voin syödä lasia, se ei vahingoita minua." -- Suomi / Finnish
+  , "Sáhtán borrat lása, dat ii leat bávččas." -- Sami (Northern)
+  , "Мон ярсан суликадо, ды зыян эйстэнзэ а ули." -- Erzian
+  , "Mie voin syvvä lasie ta minla ei ole kipie." -- Northern Karelian
+  , "Minä voin syvvä st'oklua dai minule ei ole kibie. " -- Southern Karelian
+  , "Ma võin klaasi süüa, see ei tee mulle midagi." -- Estonian
+  , "Es varu ēst stiklu, tas man nekaitē." -- Latvian
+  , "Aš galiu valgyti stiklą ir jis manęs nežeidžia " -- Lithuanian
+  , "Mohu jíst sklo, neublíží mi." -- Czech
+  , "Môžem jesť sklo. Nezraní ma." -- Slovak
+  , "Mogę jeść szkło i mi nie szkodzi." -- Polska / Polish
+  , "Lahko jem steklo, ne da bi mi škodovalo." -- Slovenian
+  , "Ja mogu jesti staklo, i to mi ne šteti." -- Bosnian, Croatian, Montenegrin and Serbian (Latin)
+  , "Ја могу јести стакло, и то ми не штети." -- Bosnian, Montenegrin and Serbian (Cyrillic)
+  , "Можам да јадам стакло, а не ме штета." -- Macedonian
+  , "Я могу есть стекло, оно мне не вредит." -- Russian
+  , "Я магу есці шкло, яно мне не шкодзіць." -- Belarusian (Cyrillic)
+  , "Ja mahu jeści škło, jano mne ne škodzić." -- Belarusian (Lacinka)
+  , "Я можу їсти скло, і воно мені не зашкодить." -- Ukrainian
+  , "Мога да ям стъкло, то не ми вреди." -- Bulgarian
+  , "მინას ვჭამ და არა მტკივა." -- Georgian
+  , "Կրնամ ապակի ուտել և ինծի անհանգիստ չըներ։" -- Armenian
+  , "Unë mund të ha qelq dhe nuk më gjen gjë." -- Albanian
+  , "Cam yiyebilirim, bana zararı dokunmaz." -- Turkish
+  , "جام ييه بلورم بڭا ضررى طوقونمز" -- Turkish (Ottoman)
+  , "Men shisha yeyishim mumkin, ammo u menga zarar keltirmaydi." -- Uzbek / O’zbekcha (Roman)
+  , "Мен шиша ейишим мумкин, аммо у менга зарар келтирмайди." -- Uzbek / Ўзбекча (Cyrillic)
+  , "আমি কাঁচ খেতে পারি, তাতে আমার কোনো ক্ষতি হয় না।" -- Bangla / Bengali
+  , "मी काच खाऊ शकतो, मला ते दुखत नाही." -- Marathi
+  , "ನನಗೆ ಹಾನಿ ಆಗದೆ, ನಾನು ಗಜನ್ನು ತಿನಬಹುದು" -- Kannada
+  , "मैं काँच खा सकता हूँ और मुझे उससे कोई चोट नहीं पहुंचती." -- Hindi
+  , "എനിക്ക് ഗ്ലാസ് തിന്നാം. അതെന്നെ വേദനിപ്പിക്കില്ല." -- Malayam
+  , "நான் கண்ணாடி சாப்பிடுவேன், அதனால் எனக்கு ஒரு கேடும் வராது." -- Tamil
+  , "నేను గాజు తినగలను మరియు అలా చేసినా నాకు ఏమి ఇబ్బంది లేదు" -- Telugu
+  , "මට වීදුරු කෑමට හැකියි. එයින් මට කිසි හානියක් සිදු නොවේ." -- Sinhalese
+  , "میں کانچ کھا سکتا ہوں اور مجھے تکلیف نہیں ہوتی ۔" -- Urdu
+  , "زه شيشه خوړلې شم، هغه ما نه خوږوي" -- Pashto
+  , ".من می توانم بدونِ احساس درد شيشه بخورم" -- Farsi / Persian
+  , "أنا قادر على أكل الزجاج و هذا لا يؤلمني. " -- Arabic
+  , "Nista' niekol il-ħ ġieġ u ma jagħmilli xejn." --Maltese
+  , "אני יכול לאכול זכוכית וזה לא מזיק לי." -- Hebrew
+  , "איך קען עסן גלאָז און עס טוט מיר נישט װײ. " -- Yiddish
+  , "Metumi awe tumpan, ɜnyɜ me hwee." -- Twi
+  , "Inā iya taunar gilāshi kuma in gamā lāfiyā." -- Hausa (Latin)
+  , "إِنا إِىَ تَونَر غِلَاشِ كُمَ إِن غَمَا لَافِىَا" -- Hausa (Ajami)
+  , "Mo lè je̩ dígí, kò ní pa mí lára." -- Yoruba
+  , "Nakokí kolíya biténi bya milungi, ekosála ngáí mabé tɛ́." -- Lingala
+  , "Naweza kula bilauri na sikunyui." -- (Ki)Swahili
+  , "Saya boleh makan kaca dan ia tidak mencederakan saya." -- Malay
+  , "Kaya kong kumain nang bubog at hindi ako masaktan." -- Tagalog
+  , "Siña yo' chumocho krestat, ti ha na'lalamen yo'." -- Chamorro
+  , "Au rawa ni kana iloilo, ia au sega ni vakacacani kina." -- Fijian
+  , "Aku isa mangan beling tanpa lara." -- Javanese
+  , "က္ယ္ဝန္တော္၊က္ယ္ဝန္မ မ္ယက္စားနုိင္သည္။ ၎က္ရောင္ ထိခုိက္မ္ဟု မရ္ဟိပာ။" -- Burmese (Unicode 4.0)
+  , "ကျွန်တော် ကျွန်မ မှန်စားနိုင်တယ်။ ၎င်းကြောင့် ထိခိုက်မှုမရှိပါ။" -- Burmese (Unicode 5.0)
+  , "Tôi có thể ăn thủy tinh mà không hại gì." -- Vietnamese (quốc ngữ)
+  , "些 𣎏 世 咹 水 晶 𦓡 空 𣎏 害 咦" -- Vietnamese (nôm)
+  , "ខ្ញុំអាចញុំកញ្ចក់បាន ដោយគ្មានបញ្ហារ" -- Khmer
+  , "ຂອ້ຍກິນແກ້ວໄດ້ໂດຍທີ່ມັນບໍ່ໄດ້ເຮັດໃຫ້ຂອ້ຍເຈັບ." -- Lao
+  , "ฉันกินกระจกได้ แต่มันไม่ทำให้ฉันเจ็บ" -- Thai
+  , "Би шил идэй чадна, надад хортой биш" -- Mongolian (Cyrillic)
+  , "ᠪᠢ ᠰᠢᠯᠢ ᠢᠳᠡᠶᠦ ᠴᠢᠳᠠᠨᠠ ᠂ ᠨᠠᠳᠤᠷ ᠬᠣᠤᠷᠠᠳᠠᠢ ᠪᠢᠰᠢ " -- Mongolian (Classic)
+  , "म काँच खान सक्छू र मलाई केहि नी हुन्न् ।" -- Nepali
+  , "ཤེལ་སྒོ་ཟ་ནས་ང་ན་གི་མ་རེད།" -- Tibetan
+  , "我能吞下玻璃而不伤身体。" -- Chinese
+  , "我能吞下玻璃而不傷身體。" -- Chinese (Traditional)
+  , "Góa ē-t àng chia̍h po-lê, mā bē tio̍h-siong." -- Taiwanese
+  , "私はガラスを食べられます。それは私を傷つけません。" -- Japanese
+  , "나는 유리를 먹을 수 있어요. 그래도 아프지 않아요" -- Korean
+  , "Mi save kakae glas, hemi no save katem mi." -- Bislama
+  , "Hiki iaʻu ke ʻai i ke aniani; ʻaʻole nō lā au e ʻeha." -- Hawaiian
+  , "E koʻana e kai i te karahi, mea ʻā, ʻaʻe hauhau." -- Marquesan
+  , "ᐊᓕᒍᖅ ᓂᕆᔭᕌᖓᒃᑯ ᓱᕋᙱᑦᑐᓐᓇᖅᑐᖓ" -- Inuktitut
+  , "Naika məkmək kakshət labutay, pi weyk ukuk munk-s ik nay." --Chinook Jargon
+  , "Tsésǫʼ yishą́ągo bííníshghah dóó doo shił neezgai da. " -- Navajo
+  , "mi kakne le nu citka le blaci .iku'i le se go'i na xrani mi" -- Lojban
+  , "Ljœr ye caudran créneþ ý jor cẃran." -- Nórdicg
+  ]
+
+------------------------------------------------------------------------
+-- Deprecated
+
+-- | Generate something in the corpus or something completely bonkers.
+genCorpus :: [a] -> (a -> b) -> Gen a -> Gen b
+genCorpus corpus f gen =
+  oneof [
+      fmap f (elements corpus)
+    , fmap f gen
+    ]
+
+-- | Shrinks 'b', preferring to return things from the corpus. If 'b' is
+--   already from the corpus then shrinks to nothing.
+shrinkCorpus :: Eq a => [a] -> (a -> b) -> (b -> a) -> (a -> [a]) -> b -> [b]
+shrinkCorpus corpus f g shrinkA b =
+  let
+    a = g b
+  in
+    if List.elem a corpus then
+      []
+    else
+      -- Items at the start of the shrink list are tried first by QuickCheck,
+      -- so put the corpus items first and hopefully we'll get a nicer
+      -- counterexample.
+      fmap f (corpus <> shrinkA a)
+
+--
+-- The newtypes below have the unXXX function defined separately so that
+-- the derived Show instance produces output which is easier to read.
+--
+
+newtype Cooking a =
+  Cooking a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unCooking :: Cooking a -> a
+unCooking (Cooking x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Cooking a) where
+  arbitrary =
+    genCorpus cooking Cooking arbitrary
+  shrink =
+    shrinkCorpus cooking Cooking unCooking shrink
+
+newtype Muppet a =
+  Muppet a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unMuppet :: Muppet a -> a
+unMuppet (Muppet x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Muppet a) where
+  arbitrary =
+    genCorpus muppets Muppet arbitrary
+  shrink =
+    shrinkCorpus muppets Muppet unMuppet shrink
+
+newtype Southpark a =
+  Southpark a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unSouthpark :: Southpark a -> a
+unSouthpark (Southpark x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Southpark a) where
+  arbitrary =
+    genCorpus southpark Southpark arbitrary
+  shrink =
+    shrinkCorpus southpark Southpark unSouthpark shrink
+
+newtype Simpson a =
+  Simpson a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unSimpson :: Simpson a -> a
+unSimpson (Simpson x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Simpson a) where
+  arbitrary =
+    genCorpus simpsons Simpson arbitrary
+  shrink =
+    shrinkCorpus simpsons Simpson unSimpson shrink
+
+
+newtype Virus a =
+  Virus a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unVirus :: Virus a -> a
+unVirus (Virus x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Virus a) where
+  arbitrary =
+    genCorpus viruses Virus arbitrary
+  shrink =
+    shrinkCorpus viruses Virus unVirus shrink
+
+newtype Colour a =
+  Colour a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unColour :: Colour a -> a
+unColour (Colour x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Colour a) where
+  arbitrary =
+    genCorpus colours Colour arbitrary
+  shrink =
+    shrinkCorpus colours Colour unColour shrink
+
+newtype Weather a =
+  Weather a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unWeather :: Weather a -> a
+unWeather (Weather x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Weather a) where
+  arbitrary =
+    genCorpus weather Weather arbitrary
+  shrink =
+    shrinkCorpus weather Weather unWeather shrink
+
+newtype Water a =
+  Water a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unWater :: Water a -> a
+unWater (Water x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Water a) where
+  arbitrary =
+    genCorpus waters Water arbitrary
+  shrink =
+    shrinkCorpus waters Water unWater shrink
+
+newtype Boat a =
+  Boat a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unBoat :: Boat a -> a
+unBoat (Boat x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Boat a) where
+  arbitrary =
+    genCorpus boats Boat arbitrary
+  shrink =
+    shrinkCorpus boats Boat unBoat shrink
+
+newtype Glass a =
+  Glass a
+  deriving (Eq, Ord, Read, Show, Generic, Data, Typeable)
+
+unGlass :: Glass a -> a
+unGlass (Glass x) =
+  x
+
+instance (Eq a, IsString a, Arbitrary a) => Arbitrary (Glass a) where
+  arbitrary =
+    genCorpus glass Glass arbitrary
+  shrink =
+    shrinkCorpus glass Glass unGlass shrink

--- a/test/Test/Mafia/Hoogle.hs
+++ b/test/Test/Mafia/Hoogle.hs
@@ -7,7 +7,7 @@ module Test.Mafia.Hoogle where
 import           Mafia.Hoogle
 import           Mafia.Package
 
-import           P
+import           Mafia.P
 
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances ()

--- a/test/Test/Mafia/IO.hs
+++ b/test/Test/Mafia/IO.hs
@@ -1,0 +1,27 @@
+module Test.Mafia.IO (
+    testIO
+  , testPropertyIO
+  , withCPUTime
+  ) where
+
+import           Control.Monad.IO.Class (liftIO, MonadIO)
+
+import           Test.QuickCheck
+import           Test.QuickCheck.Monadic
+
+import           System.CPUTime (getCPUTime)
+
+testIO :: Testable a => IO a -> Property
+testIO = testPropertyIO . run
+
+testPropertyIO :: Testable a => PropertyM IO a -> Property
+testPropertyIO = monadicIO . (=<<) stop
+
+-- | Perform an action and return the CPU time it takes, in picoseconds
+-- (actual precision varies with implementation).
+withCPUTime :: MonadIO m => m a -> m (Integer, a)
+withCPUTime a = do
+  t1 <- liftIO getCPUTime
+  r <- a
+  t2 <- liftIO getCPUTime
+  return (t2 - t1, r)

--- a/test/Test/Mafia/Main.hs
+++ b/test/Test/Mafia/Main.hs
@@ -1,0 +1,28 @@
+module Test.Mafia.Main (
+    disorderMain
+  , disorderCliMain
+  ) where
+
+import           Control.Applicative
+import           Control.Monad
+
+import           System.Directory
+import           System.Process
+import           System.Exit
+import           System.IO
+
+import           Prelude
+
+disorderMain :: [IO Bool] -> IO ()
+disorderMain tests =
+  sanity >> sequence tests >>= \rs -> unless (and rs) exitFailure
+
+disorderCliMain :: [String] -> IO ()
+disorderCliMain arguments =
+  let ignore p = ".." == p || "." == p || "core" == p
+      exec t = callProcess ("test/cli/" ++ t ++ "/run") arguments
+   in sanity >> filter (not . ignore) <$> getDirectoryContents "test/cli/" >>= mapM_ exec
+
+sanity :: IO ()
+sanity =
+  hSetBuffering stdout LineBuffering >> hSetBuffering stderr LineBuffering

--- a/test/Test/Mafia/Package.hs
+++ b/test/Test/Mafia/Package.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Test.Mafia.Package where
 
-import           Disorder.Core.Tripping (tripping)
+import           Test.Mafia.Tripping (tripping)
 
 import           Mafia.Package
 

--- a/test/Test/Mafia/Package.hs
+++ b/test/Test/Mafia/Package.hs
@@ -7,7 +7,7 @@ import           Disorder.Core.Tripping (tripping)
 
 import           Mafia.Package
 
-import           P
+import           Mafia.P
 
 import           System.IO (IO)
 

--- a/test/Test/Mafia/Process.hs
+++ b/test/Test/Mafia/Process.hs
@@ -6,10 +6,9 @@ module Test.Mafia.Process where
 
 import           Mafia.Process
 
-import           P
+import           Mafia.P
 
 import           Test.QuickCheck
-
 
 prop_clean xs =
   counterexample "contained \\b or \\r" $

--- a/test/Test/Mafia/Tripping.hs
+++ b/test/Test/Mafia/Tripping.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Test.Mafia.Tripping where
+
+import           Control.Applicative
+import           Data.Monoid
+import           Data.Function
+import           Test.QuickCheck
+
+import           Prelude
+
+-- | Generalized round-trip property function
+tripping :: (Applicative f, Show (f a), Eq (f a)) => (a -> b) -> (b -> f a) -> a -> Property
+tripping = trippingOn id
+
+trippingOn :: (Applicative f, Show (f a), Show (f c), Eq (f c)) => (a -> c) -> (a -> b) -> (b -> f a) -> a -> Property
+trippingOn f = trippingWith ((===) `on` fmap f)
+
+trippingWith :: (Applicative f, Show (f a)) => (f a -> f a -> Property) -> (a -> b) -> (b -> f a) -> a -> Property
+trippingWith prop to fro a =
+  let tripped = (fro . to) a
+      purea   = pure a
+  in counterexample (show tripped <> " /= " <> show purea)
+     (prop tripped purea)

--- a/test/test-cli.hs
+++ b/test/test-cli.hs
@@ -1,4 +1,4 @@
-import           Disorder.Core.Main
+import           Test.Mafia.Main
 
 main :: IO ()
 main =

--- a/test/test-io.hs
+++ b/test/test-io.hs
@@ -1,4 +1,4 @@
-import           Disorder.Core.Main
+import           Test.Mafia.Main
 
 import qualified Test.IO.Mafia.Chaos
 import qualified Test.IO.Mafia.Flock

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,5 +1,4 @@
-import           Disorder.Core.Main
-
+import           Test.Mafia.Main
 import qualified Test.Mafia.Cabal.Constraint
 import qualified Test.Mafia.Cabal.Dependencies
 import qualified Test.Mafia.Cabal.Types


### PR DESCRIPTION
Thought exercise in making twine an inline dependency rather than a git submodule.
Not the most minimal version of twine possible, just a working build of it.

The other option would be to make twine a real package on hackage and depend on that.

I have made a start on removing the submodules in twine here https://github.com/tmcgilchrist/twine/tree/topic/either 

The remaining issue is the use of `P` and whether that is going up on hackage or just inline a minimal version.