### PR TITLE
Make most git refs to `ambiata` repo point to `haskell-mafia`

### DIFF
--- a/docs/installing-cabal.md
+++ b/docs/installing-cabal.md
@@ -23,7 +23,7 @@ $ cp .cabal-sandbox/bin/cabal $HOME/bin/cabal
 #### Install Cabal 1.24.0.0
 
 *If you followed the advanced instructions
-[here](https://github.com/ambiata/mafia/blob/master/doc/ghc.md#advanced-multiple-ghc-versions)
+[here](https://github.com/haskell-mafia/mafia/blob/master/doc/ghc.md#advanced-multiple-ghc-versions)
 for installing multiple GHC versions, then you will need to repeat this
 step for each of the GHC versions that you have installed.*
 

--- a/docs/using-mafia.md
+++ b/docs/using-mafia.md
@@ -6,13 +6,13 @@ Mafia is designed to be run via a shell script which will bootstrap the
 `PATH` and use it like that as well.
 
 Place the
-[script](https://raw.githubusercontent.com/ambiata/mafia/master/script/mafia)
+[script](https://raw.githubusercontent.com/haskell-mafia/mafia/master/script/mafia)
 in the same directory as your `.cabal` package file and then run
 `./mafia upgrade`. This will ensure that you have the latest script and
 also bake the git hash of the Mafia version in to the script.
 
 ```
-curl -O https://raw.githubusercontent.com/ambiata/mafia/master/script/mafia && chmod +x mafia
+curl -O https://raw.githubusercontent.com/haskell-mafia/mafia/master/script/mafia && chmod +x mafia
 ```
 
 You can now run `./mafia build` for the first time. This will build the

--- a/mafia
+++ b/mafia
@@ -4,7 +4,7 @@
 : ${MAFIA_VERSIONS:=$MAFIA_HOME/versions}
 
 latest_version () {
-    git ls-remote https://github.com/ambiata/mafia | grep refs/heads/master | cut -f 1
+    git ls-remote https://github.com/haskell-mafia/mafia | grep refs/heads/master | cut -f 1
 }
 
 build_version() {
@@ -14,7 +14,7 @@ build_version() {
     MAFIA_PATH=$MAFIA_VERSIONS/$MAFIA_FILE
     mkdir -p $MAFIA_VERSIONS
     echo "Building $MAFIA_FILE in $MAFIA_TEMP"
-    git clone https://github.com/ambiata/mafia $MAFIA_TEMP
+    git clone https://github.com/haskell-mafia/mafia $MAFIA_TEMP
     git --git-dir="$MAFIA_TEMP/.git" --work-tree="$MAFIA_TEMP" reset --hard $MAFIA_VERSION || {
         echo "mafia version ($MAFIA_VERSION) could not be found." >&2
         exit 1

--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -401,7 +401,7 @@ scriptRead =
       Left $
         "Something went wrong, '" <> path <> "' looks like a script, but script" <>
         " execution should have been handled in an earlier code path.\n" <>
-        "Please report this as a bug: https://github.com/ambiata/mafia/issues"
+        "Please report this as a bug: https://github.com/haskell-mafia/mafia/issues"
     else
       Left $
         "Invalid argument '" <> path <> "', not a valid command or a valid script path.\n" <>

--- a/script/mafia
+++ b/script/mafia
@@ -4,7 +4,7 @@
 : ${MAFIA_VERSIONS:=$MAFIA_HOME/versions}
 
 latest_version () {
-    git ls-remote https://github.com/ambiata/mafia | grep refs/heads/master | cut -f 1
+    git ls-remote https://github.com/haskell-mafia/mafia | grep refs/heads/master | cut -f 1
 }
 
 build_version() {


### PR DESCRIPTION
Ambiata has forked `mafia` from `haskell-mafia` following build failures
on GHC 7.10; this makes sure `haskell-mafia` won't get weird build
failures by ensuring that any git references should be to the new
`haskell-mafia` project instead of to `ambiata`.