### PR TITLE
Fix missing-home-modules warning

### DIFF
--- a/ambiata-mafia.cabal
+++ b/ambiata-mafia.cabal
@@ -127,6 +127,14 @@ executable mafia
   main-is:
                     ../main/mafia.hs
 
+  other-modules:
+                    BuildInfo_ambiata_mafia
+                    DependencyInfo_ambiata_mafia
+
+  autogen-modules:
+                    BuildInfo_ambiata_mafia
+                    DependencyInfo_ambiata_mafia
+
   build-depends:
                       base
                     , ambiata-mafia


### PR DESCRIPTION
Lets see if this builds with all combinations of GHC and cabal.