### PR TITLE
Update cabal install doc to include 2.0.0.1

### DIFF
--- a/docs/installing-cabal.md
+++ b/docs/installing-cabal.md
@@ -37,10 +37,6 @@ didn't use the `bootstrap.sh` script, then make sure you run `cabal
 --version` to double check the version of the Cabal library that you
 need.
 
-*GHC 8.0.1 ships with Cabal-1.24.0.2 out of the box, so you may already
-have it installed. In any case, there is no harm in performing this step
-redundantly.*
-
 ```sh
 # double-check that we're installing the right version of the Cabal library
 $ cabal --version

--- a/docs/installing-cabal.md
+++ b/docs/installing-cabal.md
@@ -5,22 +5,23 @@ Cabal comes in two parts, the `cabal` executable (which is in the
 cabal-install package) and the Cabal library (which is in the Cabal
 package).
 
-#### Install cabal-install 1.24.0.0
+#### Install cabal-install 1.24.0.2/2.0.0.1
 
 These instructions copy the `cabal` executable to `$HOME/bin` which is
 assumed to be on your `$PATH`. If you have an alternative location where
 you prefer to put executables, then use that instead.
 
 ```sh
-$ wget http://hackage.haskell.org/package/cabal-install-1.24.0.0/cabal-install-1.24.0.0.tar.gz
-$ tar xf cabal-install-1.24.0.0.tar.gz
-$ cd cabal-install-1.24.0.0
+$ VER=1.24.0.2 # or 2.0.0.1 if using 8.2.2 or higher.
+$ wget https://hackage.haskell.org/package/cabal-install-${VER}/cabal-install-${VER}.tar.gz
+$ tar xf cabal-install-${VER}.tar.gz
+$ cd cabal-install-${VER}
 $ EXTRA_CONFIGURE_OPTS="" ./bootstrap.sh --sandbox --no-doc
 # $HOME/bin is assumed to exist and be on your $PATH
 $ cp .cabal-sandbox/bin/cabal $HOME/bin/cabal
 ```
 
-#### Install Cabal 1.24.0.0
+#### Install Cabal 1.24.0.2
 
 *If you followed the advanced instructions
 [here](https://github.com/haskell-mafia/mafia/blob/master/doc/ghc.md#advanced-multiple-ghc-versions)
@@ -36,18 +37,18 @@ didn't use the `bootstrap.sh` script, then make sure you run `cabal
 --version` to double check the version of the Cabal library that you
 need.
 
-*GHC 8.0.1 ships with Cabal-1.24.0.0 out of the box, so you may already
+*GHC 8.0.1 ships with Cabal-1.24.0.2 out of the box, so you may already
 have it installed. In any case, there is no harm in performing this step
 redundantly.*
 
 ```sh
 # double-check that we're installing the right version of the Cabal library
 $ cabal --version
-cabal-install version 1.24.0.0
-using version 1.24.0.0 of the Cabal library
+cabal-install version 1.24.0.2
+using version 1.24.2.0 of the Cabal library
 # make sure we're not in a sandbox, jumping to $HOME is a safe bet
 $ cd
-$ cabal install Cabal-1.24.0.0
+$ cabal install Cabal-1.24.0.2
 ```
 
 If you need to install a newer Cabal library, you don't need to remove


### PR DESCRIPTION
Possibly not quite complete. Should we:

* Simply specify `mkdir $HOME/bin` instead of the comment re: assumption?
* Update versioning info for the library doc segment?
* ~~The GHC install guides plunk `ghc` into `$HOME/haskell`, but the lock down comment mentions `$HOME/.ghc`, does this need to be updated as well?~~

@tmcgilchrist 