### PR TITLE
Bump version bounds to give a build plan on GHC 8.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
  - GHCVER=7.10.3 CABALVER=2.0
  - GHCVER=8.0.2 CABALVER=2.0
  - GHCVER=8.2.2 CABALVER=2.0
+ - GHCVER=8.4.1 CABALVER=2.0
 
 before_install:
  - sudo add-apt-repository -y ppa:hvr/ghc

--- a/mafia.cabal
+++ b/mafia.cabal
@@ -30,7 +30,7 @@ library
   build-depends:
                       base                            >= 3          && < 5
                     , aeson                           >= 0.8        && < 0.12
-                    , async                           >= 2.0        && < 2.2
+                    , async                           >= 2.0        && < 2.3
                     , attoparsec                      >= 0.12       && < 0.14
                     , base16-bytestring               == 0.1.*
                     , bytestring                      == 0.10.*
@@ -47,11 +47,11 @@ library
                     , memory                          >= 0.12       && < 0.15
                     , optparse-applicative            >= 0.11       && < 0.15
                     , parallel                        == 3.2.*
-                    , process                         >= 1.4        && < 1.5
+                    , process                         >= 1.4        && < 1.7
                     , retry                           == 0.7.*
                     , SafeSemaphore                   == 0.10.*
                     , stm                             == 2.4.*
-                    , tar                             == 0.4.*
+                    , tar                             >= 0.4        && < 0.6
                     , temporary                       == 1.2.*
                     , text                            == 1.2.*
                     , time                            >= 1.4        && < 1.9
@@ -182,7 +182,7 @@ test-suite test
                       base                            >= 3          && < 5
                     , mafia
                     , directory                       >= 1.2        && < 1.4
-                    , process                         >= 1.2        && < 1.5
+                    , process                         >= 1.2        && < 1.7
                     , QuickCheck                      == 2.8.*
                     , quickcheck-instances            == 0.3.*
                     , text
@@ -213,11 +213,11 @@ test-suite test-io
   build-depends:
                       base                            >= 3          && < 5
                     , mafia
-                    , async                           >= 2.0        && < 2.2
+                    , async                           >= 2.0        && < 2.3
                     , containers                      == 0.5.*
                     , directory                       >= 1.2        && < 1.4
                     , exceptions                      == 0.8.*
-                    , process                         >= 1.2        && < 1.5
+                    , process                         >= 1.2        && < 1.7
                     , QuickCheck                      == 2.8.*
                     , quickcheck-instances            == 0.3.*
                     , temporary                       == 1.2.*
@@ -251,6 +251,6 @@ test-suite test-cli
                       base                            >= 3          && < 5
                     , mafia
                     , directory                       >= 1.2        && < 1.4
-                    , process                         >= 1.2        && < 1.5
+                    , process                         >= 1.2        && < 1.7
                     , QuickCheck                      == 2.8.*
                     , transformers


### PR DESCRIPTION
Note that this is the minimal set of bound updates that give 8.4 support -- there are other dependencies that could be upgraded too, but they are unrelated.