### PR TITLE
Added cabal version info to the version flag

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -74,6 +74,7 @@ genBuildInfo verbosity pkg = do
       targetText = "gen/version.txt"
   t <- timestamp verbosity
   gv <- gitVersion verbosity
+  cv <- cabalVersion verbosity
   let v = showVersion version
   let buildVersion = intercalate "-" [v, t, gv]
   rewriteFile targetHs $ unlines [
@@ -84,6 +85,8 @@ genBuildInfo verbosity pkg = do
     , "buildInfo = RuntimeBuildInfo \"" ++ v ++ "\" \"" ++ t ++ "\" \"" ++ gv ++ "\""
     , "buildInfoVersion :: String"
     , "buildInfoVersion = \"" ++ buildVersion ++ "\""
+    , "cabalVersion :: String"
+    , "cabalVersion = \"" ++ cv ++ "\""
     ]
   rewriteFile targetText buildVersion
 
@@ -110,6 +113,9 @@ genDependencyInfo verbosity pkg info = do
     , "dependencyInfo :: [String]"
     , "dependencyInfo = [\n    " ++ intercalate "\n  , " strs ++ "\n  ]"
     ]
+
+cabalVersion :: Verbosity -> IO String
+cabalVersion verbosity = fmap (head . lines) $ rawSystemStdout verbosity "cabal" ["--numeric-version"]
 
 gitVersion :: Verbosity -> IO String
 gitVersion verbosity = do

--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -68,7 +68,7 @@ main = do
       -- bypass optparse until https://github.com/pcapriotti/optparse-applicative/pull/234 is merged
       runOrDie $ MafiaScript (T.pack path) (fmap T.pack args)
     _ ->
-      cli "mafia" buildInfoVersion dependencyInfo parser runOrDie
+      cli "mafia" buildInfoVersion cabalVersion dependencyInfo parser runOrDie
 
 runOrDie :: MafiaCommand -> IO ()
 runOrDie =

--- a/src/Mafia/Options/Applicative.hs
+++ b/src/Mafia/Options/Applicative.hs
@@ -23,13 +23,10 @@ import qualified Data.Attoparsec.Text as A
 import           Data.String (String)
 import qualified Data.Text as T
 
-import           Distribution.Version (Version, versionNumbers)
-
 import           Options.Applicative as X
 import           Options.Applicative.Types as X
 
 import           Mafia.P
-import           Mafia.Cabal.Version
 
 import           System.Exit (exitSuccess, ExitCode(..), exitWith)
 import           System.IO (IO, putStrLn, print, hPutStrLn, stderr)
@@ -44,9 +41,6 @@ data SafeCommand a =
   | DependencyCommand
   | RunCommand RunType a
   deriving (Eq, Show)
-
-showVersion :: Version -> String
-showVersion = intercalate "." . fmap show . versionNumbers
 
 -- | Turn a parser into a ReadM
 eitherTextReader :: (e -> Text) -> (Text -> Either e a) -> ReadM a
@@ -76,22 +70,17 @@ dispatch p = customExecParser (prefs showHelpOnEmpty) (info (p <**> helper) idm)
 --
 --   Example usage:
 --
--- > cli "my-cli" buildInfoVersion dependencyInfo myThingParser $ \c ->
+-- > cli "my-cli" buildInfoVersion cabalVersion dependencyInfo myThingParser $ \c ->
 -- >  case c of
 -- >      DoThingA -> ...
 -- >      DoThingB -> ...
-cli :: Show a => [Char] -> [Char] -> [[Char]] -> Parser a -> (a -> IO b) -> IO b
-cli name v deps commandParser act = do
+cli :: Show a => [Char] -> [Char] -> [Char] -> [[Char]] -> Parser a -> (a -> IO b) -> IO b
+cli name v cv deps commandParser act = do
   dispatch (safeCommand commandParser) >>= \a ->
     case a of
       VersionCommand -> do
         putStrLn (name <> ": " <> v)
-        eitherCV <- runEitherT getCabalVersion
-        case eitherCV of
-          Right cv ->
-            putStrLn ("built with cabal version: " <> showVersion cv ) >> exitSuccess
-          Left _ ->
-            putStrLn "Unable to retrieve cabal version" >> exitSuccess
+        putStrLn ("built with cabal version: " <> cv) >> exitSuccess
       DependencyCommand ->
         mapM putStrLn deps >> exitSuccess
       RunCommand DryRun c ->

--- a/src/Mafia/Options/Applicative.hs
+++ b/src/Mafia/Options/Applicative.hs
@@ -23,10 +23,13 @@ import qualified Data.Attoparsec.Text as A
 import           Data.String (String)
 import qualified Data.Text as T
 
+import           Distribution.Version (Version, versionNumbers)
+
 import           Options.Applicative as X
 import           Options.Applicative.Types as X
 
 import           Mafia.P
+import           Mafia.Cabal.Version
 
 import           System.Exit (exitSuccess, ExitCode(..), exitWith)
 import           System.IO (IO, putStrLn, print, hPutStrLn, stderr)
@@ -41,6 +44,9 @@ data SafeCommand a =
   | DependencyCommand
   | RunCommand RunType a
   deriving (Eq, Show)
+
+showVersion :: Version -> String
+showVersion = intercalate "." . fmap show . versionNumbers
 
 -- | Turn a parser into a ReadM
 eitherTextReader :: (e -> Text) -> (Text -> Either e a) -> ReadM a
@@ -78,8 +84,14 @@ cli :: Show a => [Char] -> [Char] -> [[Char]] -> Parser a -> (a -> IO b) -> IO b
 cli name v deps commandParser act = do
   dispatch (safeCommand commandParser) >>= \a ->
     case a of
-      VersionCommand ->
-        putStrLn (name <> ": " <> v) >> exitSuccess
+      VersionCommand -> do
+        putStrLn (name <> ": " <> v)
+        eitherCV <- runEitherT getCabalVersion
+        case eitherCV of
+          Right cv ->
+            putStrLn ("built with cabal version: " <> showVersion cv ) >> exitSuccess
+          Left _ ->
+            putStrLn "Unable to retrieve cabal version" >> exitSuccess
       DependencyCommand ->
         mapM putStrLn deps >> exitSuccess
       RunCommand DryRun c ->


### PR DESCRIPTION
I wrote up a quick patch for #178 by just calling for the cabal version directly in Applicative. I did notice that most of the other version info is being put inside of BuildInfo_mafia when it's generated, so I can move the cabal version call over there if you think that's a better place.