### PR TITLE
Add dist-newstyle paths to submodule filter

### DIFF
--- a/src/Mafia/Submodule.hs
+++ b/src/Mafia/Submodule.hs
@@ -135,6 +135,7 @@ getSourcesFrom dir = do
            . fmap   (dir' </>)
            . fmap   (takeDirectory)
            . filter (not . T.isInfixOf ".cabal-sandbox/")
+           . filter (not . T.isPrefixOf "dist-newstyle/")
            . filter (not . T.isPrefixOf "lib/")
            . filter (not . T.isPrefixOf "bin/")
            . filter (extension ".cabal")


### PR DESCRIPTION
This just allows `mafia` to work in a git checkout where `cabal new-build`
is also being used.
    
Cabal's `new-build` set of commands store things in a top level
`dist-newstyle/` directory (similar to the `.cabal-sandbox` dirwectory)
which is likely to include cabal files.

