### PR TITLE
Use hoogle executable installed on PATH, supporting both Hoogle 4 and 5.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
  - GHCVER=8.2.2 CABALVER=1.24
  - GHCVER=8.0.2 CABALVER=2.0
  - GHCVER=8.2.2 CABALVER=2.0
+ - GHCVER=8.4.4 CABALVER=2.0
 
 cache:
   directories:

--- a/main/mafia.hs
+++ b/main/mafia.hs
@@ -750,7 +750,7 @@ appendStandardDirs dir =
 
 standardSourceDirs :: [Directory]
 standardSourceDirs =
-  ["src", "test", "gen", "dist/build", "dist/build/autogen"]
+  ["src", "test", "gen", "dist/build", "dist/build/autogen", "dist/build/global-autogen"]
 
 ensureDirectory :: MonadIO m => Directory -> m (Maybe Directory)
 ensureDirectory dir = do

--- a/src/Mafia/Cabal/Version.hs
+++ b/src/Mafia/Cabal/Version.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Mafia.Cabal.Version

--- a/src/Mafia/Git.hs
+++ b/src/Mafia/Git.hs
@@ -91,7 +91,7 @@ getSubmodules = do
   root    <- getProjectRoot
   Out out <- callFrom GitProcessError root "git" ["submodule"]
 
-  sequence . fmap parseSubmoduleLine . T.lines $ out
+  traverse parseSubmoduleLine . T.lines $ out
 
 parseSubmoduleLine :: Text -> EitherT GitError IO Submodule
 parseSubmoduleLine line = Submodule (parseSubmoduleState line) <$> parseSubmoduleName line

--- a/src/Mafia/Hoogle.hs
+++ b/src/Mafia/Hoogle.hs
@@ -8,8 +8,8 @@ module Mafia.Hoogle
   , joinHooglePackages
   ) where
 
-import           Control.Monad.Trans.Bifunctor (firstT, bimapT)
-import           Control.Monad.Trans.Either (EitherT, hoistEither, runEitherT)
+import           Control.Monad.Trans.Bifunctor (firstT)
+import           Control.Monad.Trans.Either (EitherT, hoistEither, runEitherT, left)
 
 import qualified Data.List as L
 import           Data.Map (Map)
@@ -17,7 +17,6 @@ import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 
-import           Mafia.Bin
 import           Mafia.Cabal
 import           Mafia.Error
 import           Mafia.Hash
@@ -34,6 +33,15 @@ import           System.IO (IO, stderr)
 newtype HooglePackagesSandbox = HooglePackagesSandbox [PackageId]
 newtype HooglePackagesCached = HooglePackagesCached [PackageId]
 
+data Hoogle =
+  Hoogle {
+      hooglePath :: File
+    , _hoogleVersion :: HoogleVersion
+    }
+
+data HoogleVersion =
+    Hoogle4x
+  | Hoogle5x
 
 hoogle :: Text -> [Argument] -> EitherT MafiaError IO ()
 hoogle hackageRoot args = do
@@ -41,18 +49,19 @@ hoogle hackageRoot args = do
   hpc <- hooglePackagesCached
   hoogleIndex args $ joinHooglePackages hpc hp
 
+-- | Download all packages installed in the local sandbox into a global location
 hooglePackages :: Text -> EitherT MafiaError IO HooglePackagesSandbox
 hooglePackages hackageRoot = do
   firstT MafiaInitError $ initialize LatestSources Nothing Nothing
   db <- hoogleCacheDir
-  hoogleExe <- findHoogleExe
+  hoogleExe <- findHoogle
   Out pkgStr <- liftCabal $ cabal "exec" ["--", "ghc-pkg", "list", "--simple-output"]
   let pkgs = T.splitOn " " . T.strip $ pkgStr
   fmap (HooglePackagesSandbox . catMaybes) . for pkgs $ \pkg -> do
     pkgId <- hoistEither . maybeToRight (MafiaParseError $ mconcat ["Invalid package: ", pkg]) . parsePackageId $ pkg
     let name = unPackageName . pkgName $ pkgId
     let txt = db </> pkg <> ".txt"
-    let hoo = hoogleDbFile db pkgId
+    let hoo = hoogleDbFile' hoogleExe db pkgId
     let skip = db </> pkg <> ".skip"
     ifM (doesFileExist skip) (pure Nothing) $
       ifM (doesFileExist hoo) (pure $ Just pkgId) $ do
@@ -65,7 +74,12 @@ hooglePackages hackageRoot = do
             liftIO $ T.writeFile (T.unpack skip) ""
             pure Nothing
           Right Hush -> do
-            call_ MafiaProcessError hoogleExe ["convert", txt]
+            case hoogleExe of
+              Hoogle hoogleExe' Hoogle4x ->
+                call_ MafiaProcessError hoogleExe' ["convert", txt]
+              Hoogle _ Hoogle5x ->
+                -- There isn't an associated hoogle 5.x command for this
+                pure ()
             pure $ Just pkgId
 
 hoogleIndex :: [Argument] -> [PackageId] -> EitherT MafiaError IO ()
@@ -77,13 +91,33 @@ hoogleIndex args pkgs = do
   --    Unfortunately hoogle doesn't like the "-$version" part :(
   let hash = renderHash .  hashText .  mconcat .  fmap renderPackageId $ pkgs
   db <- hoogleCacheDir
-  hoogleExe <- findHoogleExe
+  hoogleExe <- findHoogle
   db' <- (\d -> d </> "hoogle" </> hash) <$> liftCabal initSandbox
-  unlessM (doesFileExist $ db' </> "default.hoo") $ do
-    createDirectoryIfMissing True db'
-    -- We may also want to copy/symlink all the hoo files here to allow for partial module searching
-    call_ MafiaProcessError hoogleExe $ ["combine", "--outfile", db' </> "default.hoo"] <> fmap (hoogleDbFile db) pkgs
-  call_ MafiaProcessError hoogleExe $ ["-d", db'] <> args
+  case hoogleExe of
+    Hoogle hoogleExe' Hoogle4x -> do
+      unlessM (doesFileExist $ db' </> "default.hoo") $ do
+        createDirectoryIfMissing True db'
+        -- We may also want to copy/symlink all the hoo files here to allow for partial module searching
+        call_ MafiaProcessError hoogleExe' $
+          ["combine", "--outfile", db' </> "default.hoo"] <> fmap (hoogleDbFile db) pkgs
+      call_ MafiaProcessError (hooglePath hoogleExe) $ ["-d", db'] <> args
+
+    Hoogle hoogleExe' Hoogle5x -> do
+      unlessM (doesFileExist $ db' </> "default.hoo") $ do
+        createDirectoryIfMissing True db'
+
+        -- Link each hoogle file into `db'` directory
+        forM_ pkgs $ \pkg -> do
+          let src = db </> renderPackageId pkg <> ".txt"
+          let dst = db' </> takeFileName src
+          createSymbolicLink src dst
+
+        let a = mconcat $ [
+              ["generate", "--database", db' </> "default.hoo"
+              , "--local=" <> db']
+              ]
+        call_ MafiaProcessError hoogleExe' a
+      call_ MafiaProcessError (hooglePath hoogleExe) $ ["-d", db' </> "default.hoo"] <> args
 
 hooglePackagesCached :: (Functor m, MonadIO m) => m HooglePackagesCached
 hooglePackagesCached = do
@@ -103,24 +137,41 @@ hoogleCacheDir =
   ensureMafiaDir "hoogle"
 
 -- | Find the 'hoogle' executable on $PATH and it if isn't there, install it.
+findHoogle :: EitherT MafiaError IO Hoogle
+findHoogle = do
+  h <- findHoogleExe
+  v <- detectHoogleVersion h
+  pure $ Hoogle h v
+
 findHoogleExe :: EitherT MafiaError IO File
 findHoogleExe = do
   res <- runEitherT $ T.init . unOut <$> call MafiaProcessError "which" ["hoogle"]
   case res of
     Right path -> pure path
-    Left _ -> installHoogle
+    Left x ->
+      -- TODO More friendly error messages about expecting to find `hoogle` on $PATH
+      left . MafiaParseError $ ("Invalid hoogle version: " <> renderMafiaError x)
 
-installHoogle :: EitherT MafiaError IO File
-installHoogle =
-  bimapT MafiaBinError (</> "hoogle") $ do
-    installBinary (ipackageId "hoogle" [4, 2, 43]) [
-        -- Hoogle can't build with the shake >= 0.16
-        ConstraintBounded (mkPackageName "shake") (Exclusive (makeVersion [0])) (Just (Exclusive (makeVersion [0, 16])))
-      ]
+detectHoogleVersion :: File -> EitherT MafiaError IO HoogleVersion
+detectHoogleVersion hf = do
+  res <- T.init . unOut <$> call MafiaProcessError hf ["--version"]
+  if T.isPrefixOf "Hoogle v4." res then
+    pure Hoogle4x
+  else if T.isPrefixOf "Hoogle 5." res then
+    pure Hoogle5x
+  else
+    left . MafiaParseError $ "Invalid hoogle version: " <> res
 
 hoogleDbFile :: Directory -> PackageId -> File
 hoogleDbFile db pkg =
   db </> renderPackageId pkg <> ".hoo"
+
+hoogleDbFile' :: Hoogle -> Directory -> PackageId -> File
+hoogleDbFile' v db pkg = case v of
+  Hoogle _ Hoogle4x ->
+    db </> renderPackageId pkg <> ".hoo"
+  Hoogle _ Hoogle5x ->
+    db </> renderPackageId pkg <> ".txt"
 
 mapFromListGrouped :: Ord a => [(a, b)] -> Map a [b]
 mapFromListGrouped =


### PR DESCRIPTION
Previously we tried to install a hoogle version 4.* which was causing issues with GHC 8.2 and beyond. Now we use the hoogle executable installed on the PATH.