### PR TITLE
enable -threaded so that number of cpus are detected correctly

### DIFF
--- a/mafia.cabal
+++ b/mafia.cabal
@@ -112,7 +112,8 @@ executable mafia
                     Haskell2010
 
   ghc-options:
-                    -Wall
+                    -Wall -threaded
+                    -rtsopts
 
   hs-source-dirs:
                     gen


### PR DESCRIPTION
From builds done on GHC 8.0.2 on Centos6 + OSX without threaded enabled getDefaultWorkers returns 1. 
When enabling it, it detects 4 physical cores on my mac (as opposed to 8 logical) and correctly passes it down to cabal via `cabal install -j4` etc.

I'm also guessing that the line in `mafia.hs` has no affect without this turned on.
```haskell
setNumCapabilities nprocs
```
It was removed in this commit https://github.com/haskell-mafia/mafia/commit/8ca04e1d33c212f211bd8c7b1bc65ebd7712602c

`-rtsopts` isn't probably needed but I just mimicked how mead configured it.
(typo in branch name - meant to be topic/enable-threaded)